### PR TITLE
feat: jrdev pre-pr-review passes 1–5, artifacts, and PR handoff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Local agent run transcripts (preflight + worktrees)
 .jrdev/agent-runs/
+.jrdev/pre-pr-review/
 
 dist/*

--- a/internal/jrdev/agent.go
+++ b/internal/jrdev/agent.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -101,8 +102,16 @@ func (r OSAgentRunner) Run(cfg Config, dir string, prompt string, opts AgentRunO
 		}
 	}
 	var buf bytes.Buffer
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
+	if opts.Print {
+		cmd.Stdout = &buf
+		cmd.Stderr = &buf
+	} else {
+		// TTY mode: attach stdin; tee stdout/stderr to terminal and buffer (for COMPLETE detection).
+		cmd.Stdin = os.Stdin
+		tee := io.MultiWriter(os.Stdout, &buf)
+		cmd.Stdout = tee
+		cmd.Stderr = tee
+	}
 	runErr := cmd.Run()
 	_ = writeTextFile(filepath.Join(runDir, agentArtifactOutputFilename), buf.String())
 	if runErr != nil {

--- a/internal/jrdev/bundle.go
+++ b/internal/jrdev/bundle.go
@@ -7,5 +7,6 @@ type PromptBundle struct {
 	Review            string
 	Merge             string
 	PR                string // optional; empty skips agent-generated PR title/body
-	PrePRReviewPass1 string
+	PrePRReviewPass1  string
+	PrePRReviewPass2  string
 }

--- a/internal/jrdev/bundle.go
+++ b/internal/jrdev/bundle.go
@@ -9,4 +9,5 @@ type PromptBundle struct {
 	PR                string // optional; empty skips agent-generated PR title/body
 	PrePRReviewPass1  string
 	PrePRReviewPass2  string
+	PrePRReviewPass3  string
 }

--- a/internal/jrdev/bundle.go
+++ b/internal/jrdev/bundle.go
@@ -10,4 +10,5 @@ type PromptBundle struct {
 	PrePRReviewPass1  string
 	PrePRReviewPass2  string
 	PrePRReviewPass3  string
+	PrePRReviewPass5  string
 }

--- a/internal/jrdev/bundle.go
+++ b/internal/jrdev/bundle.go
@@ -7,5 +7,5 @@ type PromptBundle struct {
 	Review            string
 	Merge             string
 	PR                string // optional; empty skips agent-generated PR title/body
-	PrePRReviewPass1   string
+	PrePRReviewPass1 string
 }

--- a/internal/jrdev/bundle.go
+++ b/internal/jrdev/bundle.go
@@ -2,9 +2,10 @@ package jrdev
 
 // PromptBundle holds raw markdown templates (loaded beside cmd/jrdev main).
 type PromptBundle struct {
-	Plan      string
-	Implement string
-	Review    string
-	Merge     string
-	PR        string // optional; empty skips agent-generated PR title/body
+	Plan              string
+	Implement         string
+	Review            string
+	Merge             string
+	PR                string // optional; empty skips agent-generated PR title/body
+	PrePRReviewPass1   string
 }

--- a/internal/jrdev/gitops.go
+++ b/internal/jrdev/gitops.go
@@ -304,6 +304,31 @@ func GitDiffForPrompt(workDir string) (string, error) {
 	return GitDiffForPromptFromBase(workDir, "main")
 }
 
+// GitWorkingTreeClean reports whether git status --porcelain is empty in workDir (no staged/unstaged/untracked changes).
+func GitWorkingTreeClean(workDir string) (bool, error) {
+	c := exec.Command("git", "-C", workDir, "status", "--porcelain")
+	out, err := c.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("git status --porcelain: %w\n%s", err, out)
+	}
+	s := strings.TrimSpace(string(out))
+	return s == "", nil
+}
+
+// RequireGitWorkingTreeClean returns an error when the worktree is not clean, including porcelain output for debugging.
+func RequireGitWorkingTreeClean(workDir string) error {
+	ok, err := GitWorkingTreeClean(workDir)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+	c := exec.Command("git", "-C", workDir, "status", "--porcelain")
+	out, _ := c.CombinedOutput()
+	return fmt.Errorf("jrdev pre-pr-review: working tree must be clean before advancing; git status --porcelain:\n%s", strings.TrimSpace(string(out)))
+}
+
 // MergeBranchInDir runs git merge branch --no-edit in workDir.
 func MergeBranchInDir(workDir, branch string) error {
 	c := exec.Command("git", "-C", workDir, "merge", branch, "--no-edit")

--- a/internal/jrdev/gitops.go
+++ b/internal/jrdev/gitops.go
@@ -284,14 +284,24 @@ func CommitHistoryForPrompt(workDir string) (string, error) {
 	return string(out), nil
 }
 
-// GitDiffForPrompt returns git diff main..HEAD text for prompt templates.
-func GitDiffForPrompt(workDir string) (string, error) {
-	c := exec.Command("git", "-C", workDir, "diff", "main..HEAD")
+// GitDiffForPromptFromBase returns git diff base..HEAD for prompt templates.
+// Empty base defaults to origin/main (same default as git-log issue discovery).
+func GitDiffForPromptFromBase(workDir, base string) (string, error) {
+	if strings.TrimSpace(base) == "" {
+		base = "origin/main"
+	}
+	rng := fmt.Sprintf("%s..HEAD", base)
+	c := exec.Command("git", "-C", workDir, "diff", rng)
 	out, err := c.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("git diff main..HEAD (prompt): %w\n%s", err, out)
+		return "", fmt.Errorf("git diff %s (prompt): %w\n%s", rng, err, out)
 	}
 	return string(out), nil
+}
+
+// GitDiffForPrompt returns git diff main..HEAD text for prompt templates.
+func GitDiffForPrompt(workDir string) (string, error) {
+	return GitDiffForPromptFromBase(workDir, "main")
 }
 
 // MergeBranchInDir runs git merge branch --no-edit in workDir.

--- a/internal/jrdev/gitops_test.go
+++ b/internal/jrdev/gitops_test.go
@@ -80,6 +80,50 @@ func TestGitDiffForPrompt(t *testing.T) {
 	if !strings.Contains(s, "diff --git") || !strings.Contains(s, "-a") || !strings.Contains(s, "+b") {
 		t.Fatalf("expected unified diff with change a->b: %q", s)
 	}
+
+	s2, err := GitDiffForPromptFromBase(tmp, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s2 != s {
+		t.Fatalf("GitDiffForPromptFromBase(main) mismatch\n%s\nvs\n%s", s2, s)
+	}
+}
+
+func TestGitDiffForPromptFromBase_customIntegrationBase(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	tmp := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		c := exec.Command("git", args...)
+		c.Dir = tmp
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "-b", "develop")
+	_ = exec.Command("git", "-C", tmp, "config", "user.email", "t@t").Run()
+	_ = exec.Command("git", "-C", tmp, "config", "user.name", "t").Run()
+	if err := os.WriteFile(filepath.Join(tmp, "f"), []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "f")
+	runGit("commit", "-m", "on develop")
+	runGit("checkout", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(tmp, "f"), []byte("b\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("commit", "-am", "on feature")
+
+	s, err := GitDiffForPromptFromBase(tmp, "develop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(s, "diff --git") || !strings.Contains(s, "-a") || !strings.Contains(s, "+b") {
+		t.Fatalf("expected unified diff from develop..HEAD: %q", s)
+	}
 }
 
 func TestBranchMergedIntoHead(t *testing.T) {

--- a/internal/jrdev/gitops_test.go
+++ b/internal/jrdev/gitops_test.go
@@ -212,3 +212,44 @@ func TestCreateIssueWorktree_CleansStaleBranch(t *testing.T) {
 		t.Fatalf("issue worktree HEAD: %q err=%v", strings.TrimSpace(string(out)), err)
 	}
 }
+
+func TestGitWorkingTreeClean(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	tmp := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		c := exec.Command("git", args...)
+		c.Dir = tmp
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "-b", "main")
+	_ = exec.Command("git", "-C", tmp, "config", "user.email", "t@t").Run()
+	_ = exec.Command("git", "-C", tmp, "config", "user.name", "t").Run()
+	if err := os.WriteFile(filepath.Join(tmp, "f"), []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "f")
+	runGit("commit", "-m", "first")
+
+	ok, err := GitWorkingTreeClean(tmp)
+	if err != nil || !ok {
+		t.Fatalf("expected clean after commit, ok=%v err=%v", ok, err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "dirty"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ok2, err := GitWorkingTreeClean(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok2 {
+		t.Fatal("expected dirty with untracked file")
+	}
+	if err := RequireGitWorkingTreeClean(tmp); err == nil {
+		t.Fatal("expected RequireGitWorkingTreeClean error")
+	}
+}

--- a/internal/jrdev/issue_refs.go
+++ b/internal/jrdev/issue_refs.go
@@ -1,0 +1,136 @@
+package jrdev
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+func execGit(workDir string, args ...string) *exec.Cmd {
+	c := exec.Command("git", append([]string{"-C", workDir}, args...)...)
+	return c
+}
+
+var issueCloseKeywordsRe = regexp.MustCompile(`(?i)\b(?:fixes|closes|resolves)\s*:?\s*#\s*(\d+)\b`)
+
+// ParseIssueRefsFromGitLogMessage extracts GitHub issue numbers from a single commit message
+// (subject + body) using Fixes|Closes|Resolves #<n> patterns (case-insensitive).
+func ParseIssueRefsFromGitLogMessage(msg string) []int {
+	seen := map[int]struct{}{}
+	for _, m := range issueCloseKeywordsRe.FindAllStringSubmatch(msg, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		n, err := strconv.Atoi(m[1])
+		if err != nil || n <= 0 {
+			continue
+		}
+		seen[n] = struct{}{}
+	}
+	out := make([]int, 0, len(seen))
+	for n := range seen {
+		out = append(out, n)
+	}
+	sort.Ints(out)
+	return out
+}
+
+// GitLogMessagesInRange returns commit messages (format %B) for base..HEAD in workDir.
+func GitLogMessagesInRange(workDir, base string) (string, error) {
+	if strings.TrimSpace(base) == "" {
+		base = "origin/main"
+	}
+	rng := fmt.Sprintf("%s..HEAD", base)
+	c := execGit(workDir, "log", rng, "--format=%B", "--no-merges")
+	out, err := c.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git log %s: %w\n%s", rng, err, out)
+	}
+	return string(out), nil
+}
+
+// ParseIssueRefsFromGitLogRange parses all issue references from git log base..HEAD in workDir.
+func ParseIssueRefsFromGitLogRange(workDir, base string) ([]int, error) {
+	text, err := GitLogMessagesInRange(workDir, base)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIssueRefsFromGitLogMessage(text), nil
+}
+
+// GitCurrentBranch returns the current branch short name in workDir (or "HEAD" if detached).
+func GitCurrentBranch(workDir string) (string, error) {
+	c := execGit(workDir, "rev-parse", "--abbrev-ref", "HEAD")
+	out, err := c.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse --abbrev-ref HEAD: %w\n%s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// PRClosingIssueNumbersFromGH returns issue numbers linked as closing references from
+// gh pr view for the given head branch. Only call when the PR exists — on typical
+// "no PR" errors this returns (nil, nil).
+func PRClosingIssueNumbersFromGH(cfg Config, headBranch string) ([]int, error) {
+	headBranch = strings.TrimSpace(headBranch)
+	if headBranch == "" || headBranch == "HEAD" {
+		return nil, nil
+	}
+	out, err := ghCmd(cfg, "pr", "view", headBranch, "--json", "closingIssuesReferences").CombinedOutput()
+	if err != nil {
+		s := strings.ToLower(string(out))
+		if strings.Contains(s, "no pull requests found") ||
+			strings.Contains(s, "could not find pull request") ||
+			strings.Contains(s, "not found") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("gh pr view %q: %w\n%s", headBranch, err, out)
+	}
+	var v struct {
+		ClosingIssuesReferences *struct {
+			Nodes []struct {
+				Number int `json:"number"`
+			} `json:"nodes"`
+		} `json:"closingIssuesReferences"`
+	}
+	if err := json.Unmarshal(out, &v); err != nil {
+		return nil, fmt.Errorf("gh pr view json: %w", err)
+	}
+	if v.ClosingIssuesReferences == nil {
+		return nil, nil
+	}
+	seen := map[int]struct{}{}
+	for _, node := range v.ClosingIssuesReferences.Nodes {
+		if node.Number > 0 {
+			seen[node.Number] = struct{}{}
+		}
+	}
+	outN := make([]int, 0, len(seen))
+	for n := range seen {
+		outN = append(outN, n)
+	}
+	sort.Ints(outN)
+	return outN, nil
+}
+
+// UnionSortedInts returns the sorted unique union of all slices.
+func UnionSortedInts(slices ...[]int) []int {
+	seen := map[int]struct{}{}
+	for _, s := range slices {
+		for _, n := range s {
+			if n > 0 {
+				seen[n] = struct{}{}
+			}
+		}
+	}
+	out := make([]int, 0, len(seen))
+	for n := range seen {
+		out = append(out, n)
+	}
+	sort.Ints(out)
+	return out
+}

--- a/internal/jrdev/issue_refs_test.go
+++ b/internal/jrdev/issue_refs_test.go
@@ -17,6 +17,7 @@ func TestParseIssueRefsFromGitLogMessage(t *testing.T) {
 		{"prefix Closes  #7 suffix", []int{7}},
 		{"multiline\n\nresolves #1\nFixes #2", []int{1, 2}},
 		{"Fixes: #5", []int{5}},
+		{"Fixes#6", []int{6}},
 		{"no match here", nil},
 		{"Fixes gh-12", nil},
 	}

--- a/internal/jrdev/issue_refs_test.go
+++ b/internal/jrdev/issue_refs_test.go
@@ -1,0 +1,41 @@
+package jrdev
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseIssueRefsFromGitLogMessage(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want []int
+	}{
+		{"", nil},
+		{"fixes #12", []int{12}},
+		{"Fixes #3 and closes #4", []int{3, 4}},
+		{"RESOLVES: #99", []int{99}},
+		{"prefix Closes  #7 suffix", []int{7}},
+		{"multiline\n\nresolves #1\nFixes #2", []int{1, 2}},
+		{"Fixes: #5", []int{5}},
+		{"no match here", nil},
+		{"Fixes gh-12", nil},
+	}
+	for _, tc := range cases {
+		got := ParseIssueRefsFromGitLogMessage(tc.msg)
+		if len(got) != len(tc.want) {
+			t.Fatalf("msg %q: got %v want %v", tc.msg, got, tc.want)
+		}
+		if len(tc.want) > 0 && !reflect.DeepEqual(got, tc.want) {
+			t.Fatalf("msg %q: got %v want %v", tc.msg, got, tc.want)
+		}
+	}
+}
+
+func TestUnionSortedInts(t *testing.T) {
+	got := UnionSortedInts([]int{3, 1}, []int{2, 3}, nil, []int{5})
+	want := []int{1, 2, 3, 5}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+

--- a/internal/jrdev/markdown_fence.go
+++ b/internal/jrdev/markdown_fence.go
@@ -1,0 +1,52 @@
+package jrdev
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var fenceStartForTag = func(tag string) *regexp.Regexp {
+	// Case-insensitive opening fence: ```tag optional whitespace
+	escaped := regexp.QuoteMeta(strings.ToLower(tag))
+	return regexp.MustCompile("(?i)^```\\s*" + escaped + "\\s*$")
+}
+
+// ExtractSingleMarkdownFence returns the inner text of exactly one ```tag fenced block (opening tag match is case-insensitive).
+func ExtractSingleMarkdownFence(tag, agentOutput string) (inner string, err error) {
+	re := fenceStartForTag(tag)
+	lines := strings.Split(agentOutput, "\n")
+	var starts []int
+	for i, line := range lines {
+		if re.MatchString(strings.TrimRight(line, "\r")) {
+			starts = append(starts, i)
+		}
+	}
+	if len(starts) == 0 {
+		return "", fmt.Errorf("jrdev: no %q fenced code block in agent output", tag)
+	}
+	if len(starts) > 1 {
+		return "", fmt.Errorf("jrdev: expected exactly one %q fenced block, found %d", tag, len(starts))
+	}
+	startIdx := starts[0]
+	var endIdx int
+	foundEnd := false
+	for j := startIdx + 1; j < len(lines); j++ {
+		if strings.HasPrefix(strings.TrimRight(lines[j], "\r"), "```") {
+			endIdx = j
+			foundEnd = true
+			break
+		}
+	}
+	if !foundEnd {
+		return "", fmt.Errorf("jrdev: unclosed %q fenced code block", tag)
+	}
+	var b strings.Builder
+	for j := startIdx + 1; j < endIdx; j++ {
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(strings.TrimRight(lines[j], "\r"))
+	}
+	return strings.TrimSpace(b.String()), nil
+}

--- a/internal/jrdev/pr_content.go
+++ b/internal/jrdev/pr_content.go
@@ -28,12 +28,19 @@ func PullRequestTitleAndBody(cfg Config, agent AgentRunner, log func(string, ...
 		if err != nil {
 			return "", err
 		}
+		handoff, handoffWarn := LoadPRPromptPrePRReviewHandoff(intPath)
+		if handoffWarn != "" {
+			log("jrdev: warning: %s\n", handoffWarn)
+		}
 		return Render("pr", prompts.PR, PRPromptData{
-			IntegrationBranch: integrationBranch,
-			QueueLabel:        cfg.Label,
-			PRBase:            prBaseBranch,
-			CommitHistory:     hist,
-			GitDiff:           diff,
+			IntegrationBranch:         integrationBranch,
+			QueueLabel:                cfg.Label,
+			PRBase:                    prBaseBranch,
+			CommitHistory:             hist,
+			GitDiff:                   diff,
+			PrePRReviewHandoffPresent: handoff.Present,
+			PrePRReviewHandoffSummary: handoff.Summary,
+			PrePRReviewArtifactPaths:  handoff.ArtifactPaths,
 		})
 	}
 

--- a/internal/jrdev/pr_content.go
+++ b/internal/jrdev/pr_content.go
@@ -38,7 +38,7 @@ func PullRequestTitleAndBody(cfg Config, agent AgentRunner, log func(string, ...
 	}
 
 	vlog(cfg, log, "jrdev: verbose: pr description — agent run in %s\n", intPath)
-	out, err := runAgentUntilComplete(cfg, agent, log, "pr", intPath, render)
+	out, err := runAgentUntilComplete(cfg, agent, log, "pr", intPath, render, true)
 	if err != nil {
 		log("jrdev: warning: PR description agent failed (%v); using default title/body\n", err)
 		return fallbackTitle, fallbackBody

--- a/internal/jrdev/pr_content_test.go
+++ b/internal/jrdev/pr_content_test.go
@@ -1,0 +1,130 @@
+package jrdev
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadPRPromptPrePRReviewHandoff_noLatest(t *testing.T) {
+	tmp := t.TempDir()
+	h, warn := LoadPRPromptPrePRReviewHandoff(tmp)
+	if h.Present || h.Summary != "" || h.ArtifactPaths != "" {
+		t.Fatalf("expected empty handoff, got present=%v summary=%q paths=%q", h.Present, h.Summary, h.ArtifactPaths)
+	}
+	if warn == "" || !strings.Contains(warn, "latest") {
+		t.Fatalf("expected warning about latest, got %q", warn)
+	}
+}
+
+func TestLoadPRPromptPrePRReviewHandoff_missingRunDir(t *testing.T) {
+	tmp := t.TempDir()
+	latest := filepath.Join(tmp, AgentArtifactsDir, PrePrReviewArtifactsRoot, "latest")
+	if err := os.MkdirAll(filepath.Dir(latest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(latest, []byte("deadbeef\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h, warn := LoadPRPromptPrePRReviewHandoff(tmp)
+	if h.Present {
+		t.Fatal("expected present false")
+	}
+	if warn == "" || !strings.Contains(warn, "missing") {
+		t.Fatalf("expected missing dir warning, got %q", warn)
+	}
+}
+
+func TestLoadPRPromptPrePRReviewHandoff_withArtifacts(t *testing.T) {
+	tmp := t.TempDir()
+	runID := "a1b2c3d4"
+	artDir := filepath.Join(tmp, AgentArtifactsDir, PrePrReviewArtifactsRoot, runID)
+	if err := os.MkdirAll(artDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	latest := filepath.Join(tmp, AgentArtifactsDir, PrePrReviewArtifactsRoot, "latest")
+	if err := os.WriteFile(latest, []byte(runID+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sess := PrePRSessionHandoff{
+		DraftPRTitle:  "Draft title",
+		DraftPRBody:   "Draft body line",
+		GapNotes:      "gaps",
+		FinalRound:    2,
+		MatrixHadGaps: false,
+	}
+	sb, err := json.MarshalIndent(sess, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(artDir, "handoff.json"), sb, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p3 := struct {
+		FinalRound int                `json:"finalRound"`
+		Artifact   PrePRPass3Artifact `json:"artifact"`
+	}{FinalRound: 2, Artifact: PrePRPass3Artifact{Summary: "pass3sum", FollowUps: "fu"}}
+	p3b, err := json.MarshalIndent(p3, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(artDir, "pass-3.json"), p3b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p4 := prePRPass4ArtifactFile{FinalPass4Success: true}
+	p4b, err := json.MarshalIndent(p4, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(artDir, "pass-4.json"), p4b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(artDir, "round-01-pass-1.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h, warn := LoadPRPromptPrePRReviewHandoff(tmp)
+	if warn != "" {
+		t.Fatalf("unexpected warn: %s", warn)
+	}
+	if !h.Present {
+		t.Fatal("expected present")
+	}
+	if !strings.Contains(h.Summary, "Draft title") || !strings.Contains(h.Summary, "pass3sum") {
+		t.Fatalf("summary: %q", h.Summary)
+	}
+	if !strings.Contains(h.Summary, "Final Pass 4 success:** true") {
+		t.Fatalf("expected pass4 in summary: %q", h.Summary)
+	}
+	if !strings.Contains(h.ArtifactPaths, "handoff.json") || !strings.Contains(h.ArtifactPaths, "round-01-pass-1.json") {
+		t.Fatalf("paths: %q", h.ArtifactPaths)
+	}
+}
+
+func TestLoadPRPromptPrePRReviewHandoff_warnPartial(t *testing.T) {
+	tmp := t.TempDir()
+	runID := "a1b2c3d4"
+	artDir := filepath.Join(tmp, AgentArtifactsDir, PrePrReviewArtifactsRoot, runID)
+	if err := os.MkdirAll(artDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	latest := filepath.Join(tmp, AgentArtifactsDir, PrePrReviewArtifactsRoot, "latest")
+	if err := os.WriteFile(latest, []byte(runID+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Only handoff — missing pass-3 triggers secondary warning
+	if err := os.WriteFile(filepath.Join(artDir, "handoff.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h, warn := LoadPRPromptPrePRReviewHandoff(tmp)
+	if !h.Present {
+		t.Fatal("expected present")
+	}
+	if warn == "" || !strings.Contains(warn, "pass-3.json") {
+		t.Fatalf("expected pass-3 warning, got %q", warn)
+	}
+}

--- a/internal/jrdev/pr_content_test.go
+++ b/internal/jrdev/pr_content_test.go
@@ -19,6 +19,25 @@ func TestLoadPRPromptPrePRReviewHandoff_noLatest(t *testing.T) {
 	}
 }
 
+func TestLoadPRPromptPrePRReviewHandoff_invalidRunID(t *testing.T) {
+	tmp := t.TempDir()
+	latest := filepath.Join(tmp, AgentArtifactsDir, PrePrReviewArtifactsRoot, "latest")
+	if err := os.MkdirAll(filepath.Dir(latest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Path segments in latest would be unsafe in filepath.Join; must be rejected.
+	if err := os.WriteFile(latest, []byte("../evil\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h, warn := LoadPRPromptPrePRReviewHandoff(tmp)
+	if h.Present {
+		t.Fatal("expected present false for invalid run id")
+	}
+	if warn == "" || !strings.Contains(warn, "8-hex") {
+		t.Fatalf("expected invalid id warning, got %q", warn)
+	}
+}
+
 func TestLoadPRPromptPrePRReviewHandoff_missingRunDir(t *testing.T) {
 	tmp := t.TempDir()
 	latest := filepath.Join(tmp, AgentArtifactsDir, PrePrReviewArtifactsRoot, "latest")

--- a/internal/jrdev/prd_matrix.go
+++ b/internal/jrdev/prd_matrix.go
@@ -1,0 +1,136 @@
+package jrdev
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const prdMatrixFenceTag = "jrdev-prd-matrix"
+
+var allowedMatrixStatuses = map[string]struct{}{
+	"satisfied":      {},
+	"not_satisfied":  {},
+	"unknown":        {},
+	"conflict":       {},
+}
+
+// PRDMatrixEvidence models per-row evidence (GM-005).
+type PRDMatrixEvidence struct {
+	Paths []string `json:"paths"`
+	Tests []string `json:"tests"`
+}
+
+// PRDMatrixRow is one requirements matrix row.
+type PRDMatrixRow struct {
+	ID            string            `json:"id"`
+	VerbatimQuote string            `json:"verbatimQuote"`
+	Status        string            `json:"status"`
+	Evidence      PRDMatrixEvidence `json:"evidence"`
+	Notes         string            `json:"notes"`
+}
+
+// PRDMatrixDoc is the validated JSON object inside the jrdev-prd-matrix fence.
+type PRDMatrixDoc struct {
+	SchemaVersion string          `json:"schemaVersion"`
+	Requirements  []PRDMatrixRow  `json:"requirements"`
+}
+
+var fenceStartRe = regexp.MustCompile("(?i)^```\\s*" + regexp.QuoteMeta(prdMatrixFenceTag) + "\\s*$")
+
+// ExtractSinglePRDMatrixFence returns the inner text of exactly one ```jrdev-prd-matrix fenced block.
+func ExtractSinglePRDMatrixFence(agentOutput string) (inner string, err error) {
+	lines := strings.Split(agentOutput, "\n")
+	var starts []int
+	for i, line := range lines {
+		if fenceStartRe.MatchString(strings.TrimRight(line, "\r")) {
+			starts = append(starts, i)
+		}
+	}
+	if len(starts) == 0 {
+		return "", fmt.Errorf("jrdev: no %q fenced code block in agent output", prdMatrixFenceTag)
+	}
+	if len(starts) > 1 {
+		return "", fmt.Errorf("jrdev: expected exactly one %q fenced block, found %d", prdMatrixFenceTag, len(starts))
+	}
+	startIdx := starts[0]
+	var endIdx int
+	foundEnd := false
+	for j := startIdx + 1; j < len(lines); j++ {
+		if strings.HasPrefix(strings.TrimRight(lines[j], "\r"), "```") {
+			endIdx = j
+			foundEnd = true
+			break
+		}
+	}
+	if !foundEnd {
+		return "", fmt.Errorf("jrdev: unclosed %q fenced code block", prdMatrixFenceTag)
+	}
+	var b strings.Builder
+	for j := startIdx + 1; j < endIdx; j++ {
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(strings.TrimRight(lines[j], "\r"))
+	}
+	return strings.TrimSpace(b.String()), nil
+}
+
+// ValidatePRDMatrixJSON unmarshals and checks GM-005 field constraints.
+func ValidatePRDMatrixJSON(jsonText string) (PRDMatrixDoc, error) {
+	var doc PRDMatrixDoc
+	if err := json.Unmarshal([]byte(jsonText), &doc); err != nil {
+		return PRDMatrixDoc{}, fmt.Errorf("jrdev: matrix json: %w", err)
+	}
+	if strings.TrimSpace(doc.SchemaVersion) == "" {
+		return PRDMatrixDoc{}, fmt.Errorf("jrdev: matrix json: missing schemaVersion")
+	}
+	if doc.Requirements == nil {
+		return PRDMatrixDoc{}, fmt.Errorf("jrdev: matrix json: requirements must be present")
+	}
+	for i, row := range doc.Requirements {
+		if strings.TrimSpace(row.ID) == "" {
+			return PRDMatrixDoc{}, fmt.Errorf("jrdev: matrix json: requirements[%d].id empty", i)
+		}
+		if strings.TrimSpace(row.VerbatimQuote) == "" {
+			return PRDMatrixDoc{}, fmt.Errorf("jrdev: matrix json: requirements[%d].verbatimQuote empty", i)
+		}
+		st := strings.TrimSpace(row.Status)
+		if _, ok := allowedMatrixStatuses[st]; !ok {
+			return PRDMatrixDoc{}, fmt.Errorf("jrdev: matrix json: requirements[%d].status invalid %q", i, row.Status)
+		}
+		if row.Evidence.Paths == nil {
+			return PRDMatrixDoc{}, fmt.Errorf("jrdev: matrix json: requirements[%d].evidence.paths must be present (array)", i)
+		}
+		if row.Evidence.Tests == nil {
+			return PRDMatrixDoc{}, fmt.Errorf("jrdev: matrix json: requirements[%d].evidence.tests must be present (array)", i)
+		}
+		if st == "satisfied" {
+			ok := false
+			for _, t := range row.Evidence.Tests {
+				if strings.TrimSpace(t) != "" {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				return PRDMatrixDoc{}, fmt.Errorf("jrdev: matrix json: requirements[%d] status satisfied requires concrete evidence.tests", i)
+			}
+		}
+	}
+	return doc, nil
+}
+
+// PrePRMatrixRepairPrompt builds the minimal one-shot repair prompt (failing JSON + error only).
+func PrePRMatrixRepairPrompt(fencedInnerJSON, parseErr string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "You have invalid JSON that must appear inside a single markdown fenced block tagged exactly %q.\n\n", prdMatrixFenceTag)
+	fmt.Fprintf(&b, "Parse/validation error:\n%s\n\n", strings.TrimSpace(parseErr))
+	fmt.Fprintf(&b, "Failing JSON text (fix it; output only the corrected fenced block and nothing else before it):\n```%s\n%s\n```\n\n", prdMatrixFenceTag, strings.TrimSpace(fencedInnerJSON))
+	fmt.Fprintf(&b, "Output requirements:\n")
+	fmt.Fprintf(&b, "- Emit exactly one ```%s fenced block containing a single JSON object.\n", prdMatrixFenceTag)
+	fmt.Fprintf(&b, "- The JSON must satisfy the PRD requirements matrix schema (schemaVersion, requirements[] with id, verbatimQuote, status, evidence.paths, evidence.tests, notes).\n")
+	fmt.Fprintf(&b, "- End your response with the line COMPLETE on its own line.\n")
+	return b.String()
+}

--- a/internal/jrdev/prd_matrix.go
+++ b/internal/jrdev/prd_matrix.go
@@ -3,7 +3,6 @@ package jrdev
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"strings"
 )
 
@@ -37,44 +36,20 @@ type PRDMatrixDoc struct {
 	Requirements  []PRDMatrixRow  `json:"requirements"`
 }
 
-var fenceStartRe = regexp.MustCompile("(?i)^```\\s*" + regexp.QuoteMeta(prdMatrixFenceTag) + "\\s*$")
-
 // ExtractSinglePRDMatrixFence returns the inner text of exactly one ```jrdev-prd-matrix fenced block.
 func ExtractSinglePRDMatrixFence(agentOutput string) (inner string, err error) {
-	lines := strings.Split(agentOutput, "\n")
-	var starts []int
-	for i, line := range lines {
-		if fenceStartRe.MatchString(strings.TrimRight(line, "\r")) {
-			starts = append(starts, i)
+	return ExtractSingleMarkdownFence(prdMatrixFenceTag, agentOutput)
+}
+
+// PRDMatrixDocHasGaps reports whether any requirement row still needs Pass 2 attention (GM-007).
+func PRDMatrixDocHasGaps(doc PRDMatrixDoc) bool {
+	for _, row := range doc.Requirements {
+		switch strings.TrimSpace(row.Status) {
+		case "not_satisfied", "unknown", "conflict":
+			return true
 		}
 	}
-	if len(starts) == 0 {
-		return "", fmt.Errorf("jrdev: no %q fenced code block in agent output", prdMatrixFenceTag)
-	}
-	if len(starts) > 1 {
-		return "", fmt.Errorf("jrdev: expected exactly one %q fenced block, found %d", prdMatrixFenceTag, len(starts))
-	}
-	startIdx := starts[0]
-	var endIdx int
-	foundEnd := false
-	for j := startIdx + 1; j < len(lines); j++ {
-		if strings.HasPrefix(strings.TrimRight(lines[j], "\r"), "```") {
-			endIdx = j
-			foundEnd = true
-			break
-		}
-	}
-	if !foundEnd {
-		return "", fmt.Errorf("jrdev: unclosed %q fenced code block", prdMatrixFenceTag)
-	}
-	var b strings.Builder
-	for j := startIdx + 1; j < endIdx; j++ {
-		if b.Len() > 0 {
-			b.WriteByte('\n')
-		}
-		b.WriteString(strings.TrimRight(lines[j], "\r"))
-	}
-	return strings.TrimSpace(b.String()), nil
+	return false
 }
 
 // ValidatePRDMatrixJSON unmarshals and checks GM-005 field constraints.

--- a/internal/jrdev/prd_matrix_test.go
+++ b/internal/jrdev/prd_matrix_test.go
@@ -25,6 +25,11 @@ func TestExtractSinglePRDMatrixFence(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "exactly one") {
 		t.Fatalf("got %v", err)
 	}
+
+	_, err = ExtractSinglePRDMatrixFence("```jrdev-prd-matrix\n{\"x\":1}\n")
+	if err == nil || !strings.Contains(err.Error(), "unclosed") {
+		t.Fatalf("expected unclosed fence error, got %v", err)
+	}
 }
 
 func TestValidatePRDMatrixJSON(t *testing.T) {
@@ -69,6 +74,18 @@ func TestValidatePRDMatrixJSON(t *testing.T) {
 	_, err = ValidatePRDMatrixJSON(missingSchema)
 	if err == nil {
 		t.Fatal("expected schemaVersion error")
+	}
+
+	noRequirementsKey := `{"schemaVersion":"1"}`
+	_, err = ValidatePRDMatrixJSON(noRequirementsKey)
+	if err == nil || !strings.Contains(err.Error(), "requirements") {
+		t.Fatalf("expected requirements error, got %v", err)
+	}
+
+	evidencePathsNull := `{"schemaVersion":"1","requirements":[{"id":"a","verbatimQuote":"q","status":"unknown","evidence":{"paths":null,"tests":[]},"notes":""}]}`
+	_, err = ValidatePRDMatrixJSON(evidencePathsNull)
+	if err == nil || !strings.Contains(err.Error(), "paths") {
+		t.Fatalf("expected paths error, got %v", err)
 	}
 }
 

--- a/internal/jrdev/prd_matrix_test.go
+++ b/internal/jrdev/prd_matrix_test.go
@@ -1,0 +1,80 @@
+package jrdev
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractSinglePRDMatrixFence(t *testing.T) {
+	s := "intro\n\n```JrDev-PRD-Matrix\n{\"schemaVersion\":\"1\",\"requirements\":[]}\n```\n\nCOMPLETE\n"
+	inner, err := ExtractSinglePRDMatrixFence(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(inner, "schemaVersion") {
+		t.Fatalf("inner=%q", inner)
+	}
+
+	_, err = ExtractSinglePRDMatrixFence("no fence")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	two := "```jrdev-prd-matrix\n{}\n```\n```jrdev-prd-matrix\n{}\n```"
+	_, err = ExtractSinglePRDMatrixFence(two)
+	if err == nil || !strings.Contains(err.Error(), "exactly one") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestValidatePRDMatrixJSON(t *testing.T) {
+	valid := `{
+  "schemaVersion": "1",
+  "requirements": [
+    {
+      "id": "REQ-1",
+      "verbatimQuote": "Ship widget",
+      "status": "satisfied",
+      "evidence": { "paths": ["a.go"], "tests": ["a_test.go TestFoo"] },
+      "notes": ""
+    }
+  ]
+}`
+	doc, err := ValidatePRDMatrixJSON(valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc.SchemaVersion != "1" || len(doc.Requirements) != 1 {
+		t.Fatalf("%+v", doc)
+	}
+
+	_, err = ValidatePRDMatrixJSON("{")
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+
+	badStatus := `{"schemaVersion":"1","requirements":[{"id":"a","verbatimQuote":"q","status":"maybe","evidence":{"paths":[],"tests":[]},"notes":""}]}`
+	_, err = ValidatePRDMatrixJSON(badStatus)
+	if err == nil {
+		t.Fatal("expected status error")
+	}
+
+	satisfiedNoTests := `{"schemaVersion":"1","requirements":[{"id":"a","verbatimQuote":"q","status":"satisfied","evidence":{"paths":[],"tests":[]},"notes":""}]}`
+	_, err = ValidatePRDMatrixJSON(satisfiedNoTests)
+	if err == nil {
+		t.Fatal("expected satisfied/tests error")
+	}
+
+	missingSchema := `{"requirements":[]}`
+	_, err = ValidatePRDMatrixJSON(missingSchema)
+	if err == nil {
+		t.Fatal("expected schemaVersion error")
+	}
+}
+
+func TestPrePRMatrixRepairPrompt_containsFenceAndError(t *testing.T) {
+	p := PrePRMatrixRepairPrompt(`{`, "broken")
+	if !strings.Contains(p, prdMatrixFenceTag) || !strings.Contains(p, "broken") {
+		t.Fatalf("%s", p)
+	}
+}

--- a/internal/jrdev/prd_matrix_test.go
+++ b/internal/jrdev/prd_matrix_test.go
@@ -5,6 +5,17 @@ import (
 	"testing"
 )
 
+func TestPRDMatrixDocHasGaps(t *testing.T) {
+	ok := PRDMatrixDoc{Requirements: []PRDMatrixRow{{Status: "satisfied"}}}
+	if PRDMatrixDocHasGaps(ok) {
+		t.Fatal("satisfied only")
+	}
+	gap := PRDMatrixDoc{Requirements: []PRDMatrixRow{{Status: "not_satisfied"}}}
+	if !PRDMatrixDocHasGaps(gap) {
+		t.Fatal("not_satisfied is a gap")
+	}
+}
+
 func TestExtractSinglePRDMatrixFence(t *testing.T) {
 	s := "intro\n\n```JrDev-PRD-Matrix\n{\"schemaVersion\":\"1\",\"requirements\":[]}\n```\n\nCOMPLETE\n"
 	inner, err := ExtractSinglePRDMatrixFence(s)

--- a/internal/jrdev/pre_pr_review.go
+++ b/internal/jrdev/pre_pr_review.go
@@ -97,6 +97,25 @@ func newPrePRRunID() (string, error) {
 	return hex.EncodeToString(b[:]), nil
 }
 
+// isValidPrePRRunID returns true for ids produced by newPrePRRunID (8 hex digits).
+// Rejecting other values prevents ".jrdev/pre-pr-review/latest" from embedding ".." or separators in filepath.Join.
+func isValidPrePRRunID(s string) bool {
+	if len(s) != 8 {
+		return false
+	}
+	for i := 0; i < 8; i++ {
+		c := s[i]
+		switch {
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'f':
+		case c >= 'A' && c <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // FormatIssuesMarkdownForPass1 fetches bodies via gh and builds markdown sections.
 func FormatIssuesMarkdownForPass1(cfg Config, issueNums []int) (string, error) {
 	var sb strings.Builder
@@ -897,6 +916,9 @@ func LoadPRPromptPrePRReviewHandoff(workDir string) (h PRPromptPrePRReviewHandof
 	runID := strings.TrimSpace(string(rawLatest))
 	if runID == "" {
 		return PRPromptPrePRReviewHandoff{}, "pre-pr-review: .jrdev/pre-pr-review/latest is empty — PR prompt will use commit/diff context only"
+	}
+	if !isValidPrePRRunID(runID) {
+		return PRPromptPrePRReviewHandoff{}, "pre-pr-review: latest run id is not a valid 8-hex pre-pr-review id — PR prompt will use commit/diff context only"
 	}
 	artDir := filepath.Join(workDir, AgentArtifactsDir, PrePrReviewArtifactsRoot, runID)
 	st, err := os.Stat(artDir)

--- a/internal/jrdev/pre_pr_review.go
+++ b/internal/jrdev/pre_pr_review.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -748,4 +749,178 @@ finalize:
 		return err
 	}
 	return nil
+}
+
+// PRPromptPrePRReviewHandoff carries optional pre-pr-review context for prompt_pr.md (GM-012).
+type PRPromptPrePRReviewHandoff struct {
+	Present       bool
+	Summary       string // markdown fragment for the PR prompt
+	ArtifactPaths string // markdown bullet list of paths relative to repo root
+}
+
+type prPromptPass3File struct {
+	FinalRound int                `json:"finalRound"`
+	Artifact   PrePRPass3Artifact `json:"artifact"`
+}
+
+func buildPRPromptHandoffSummaryMarkdown(artDir, runID string) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "**Pre-pr-review run ID:** `%s`\n\n", runID)
+
+	hPath := filepath.Join(artDir, "handoff.json")
+	raw, err := os.ReadFile(hPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			sb.WriteString("*Session handoff (`handoff.json`) is not present for this run.*\n\n")
+		} else {
+			fmt.Fprintf(&sb, "*Could not read handoff.json: %v*\n\n", err)
+		}
+	} else {
+		var sess PrePRSessionHandoff
+		if err := json.Unmarshal(raw, &sess); err != nil {
+			fmt.Fprintf(&sb, "*handoff.json is not valid JSON: %v*\n\n", err)
+		} else {
+			sb.WriteString("### Session handoff (Pass 1↔2)\n\n")
+			if t := strings.TrimSpace(sess.DraftPRTitle); t != "" {
+				fmt.Fprintf(&sb, "- **Draft PR title:** %s\n", t)
+			}
+			if b := strings.TrimSpace(sess.DraftPRBody); b != "" {
+				fmt.Fprintf(&sb, "- **Draft PR body:**\n\n%s\n\n", b)
+			}
+			if t := strings.TrimSpace(sess.GapNotes); t != "" {
+				fmt.Fprintf(&sb, "- **Gap notes:** %s\n", t)
+			}
+			if t := strings.TrimSpace(sess.ConflictNotes); t != "" {
+				fmt.Fprintf(&sb, "- **Conflict notes:** %s\n", t)
+			}
+			fmt.Fprintf(&sb, "- **Final Pass 1↔2 round:** %d — **matrix had gaps at end:** %v\n", sess.FinalRound, sess.MatrixHadGaps)
+			if t := strings.TrimSpace(sess.Pass5BadTestByDesign); t != "" {
+				fmt.Fprintf(&sb, "- **Pass 5 — bad test by design:** %s\n", t)
+			}
+			if t := strings.TrimSpace(sess.Pass5OperatorNotes); t != "" {
+				fmt.Fprintf(&sb, "- **Pass 5 — operator notes:** %s\n", t)
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	p3raw, err := os.ReadFile(filepath.Join(artDir, "pass-3.json"))
+	if err == nil {
+		var w prPromptPass3File
+		if err := json.Unmarshal(p3raw, &w); err != nil {
+			fmt.Fprintf(&sb, "*pass-3.json is not valid JSON: %v*\n\n", err)
+		} else {
+			a := w.Artifact
+			sb.WriteString("### Pass 3 — testing review\n\n")
+			add := func(label, val string) {
+				if strings.TrimSpace(val) != "" {
+					fmt.Fprintf(&sb, "- **%s:** %s\n", label, val)
+				}
+			}
+			add("Summary", a.Summary)
+			add("Test design", a.TestDesign)
+			add("Coverage", a.Coverage)
+			add("PRD testing alignment", a.PRDTestingAlignment)
+			add("Strictness inference", a.StrictnessInference)
+			add("Follow-ups", a.FollowUps)
+			sb.WriteString("\n")
+		}
+	}
+
+	p4raw, err := os.ReadFile(filepath.Join(artDir, "pass-4.json"))
+	if err == nil {
+		var f prePRPass4ArtifactFile
+		if err := json.Unmarshal(p4raw, &f); err != nil {
+			fmt.Fprintf(&sb, "*pass-4.json is not valid JSON: %v*\n", err)
+		} else {
+			sb.WriteString("### Pass 4 — configured checks\n\n")
+			fmt.Fprintf(&sb, "- **Final Pass 4 success:** %v\n", f.FinalPass4Success)
+			if f.Pass5BudgetExhausted {
+				sb.WriteString("- **Pass 5 budget was exhausted** (workspace may still fail checks; see GM-014)\n")
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	p5raw, err := os.ReadFile(filepath.Join(artDir, "pass-5.json"))
+	if err == nil {
+		var f prePRPass5ArtifactFile
+		if err := json.Unmarshal(p5raw, &f); err != nil {
+			fmt.Fprintf(&sb, "*pass-5.json is not valid JSON: %v*\n", err)
+		} else {
+			sb.WriteString("### Pass 5 — fix loop\n\n")
+			fmt.Fprintf(&sb, "- **Recorded fix rounds:** %d\n", len(f.Rounds))
+			sb.WriteString("\n")
+		}
+	}
+
+	return strings.TrimSpace(sb.String())
+}
+
+func collectPrePRArtifactRelPaths(artDir, runID string) []string {
+	baseRel := filepath.ToSlash(filepath.Join(AgentArtifactsDir, PrePrReviewArtifactsRoot, runID))
+	var names []string
+	for _, name := range []string{"handoff.json", "pass-3.json", "pass-4.json", "pass-5.json", "pass-1.json", "pass-2.json", "raw-matrix.json"} {
+		p := filepath.Join(artDir, name)
+		if _, err := os.Stat(p); err == nil {
+			names = append(names, filepath.ToSlash(filepath.Join(baseRel, name)))
+		}
+	}
+	ents, err := os.ReadDir(artDir)
+	if err == nil {
+		for _, e := range ents {
+			n := e.Name()
+			if strings.HasPrefix(n, "round-") && (strings.HasSuffix(n, "-pass-1.json") || strings.HasSuffix(n, "-pass-2.json")) {
+				names = append(names, filepath.ToSlash(filepath.Join(baseRel, n)))
+			}
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// LoadPRPromptPrePRReviewHandoff loads the current pre-pr-review run referenced by .jrdev/pre-pr-review/latest.
+// The caller should log warn when non-empty (GM-012). When Present is false, Summary and ArtifactPaths are empty.
+func LoadPRPromptPrePRReviewHandoff(workDir string) (h PRPromptPrePRReviewHandoff, warn string) {
+	workDir, err := filepath.Abs(workDir)
+	if err != nil {
+		return PRPromptPrePRReviewHandoff{}, fmt.Sprintf("pre-pr-review handoff: abs path: %v", err)
+	}
+	latestPath := filepath.Join(workDir, AgentArtifactsDir, PrePrReviewArtifactsRoot, "latest")
+	rawLatest, err := os.ReadFile(latestPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return PRPromptPrePRReviewHandoff{}, "pre-pr-review: no .jrdev/pre-pr-review/latest — PR prompt will use commit/diff context only"
+		}
+		return PRPromptPrePRReviewHandoff{}, fmt.Sprintf("pre-pr-review: read latest pointer: %v", err)
+	}
+	runID := strings.TrimSpace(string(rawLatest))
+	if runID == "" {
+		return PRPromptPrePRReviewHandoff{}, "pre-pr-review: .jrdev/pre-pr-review/latest is empty — PR prompt will use commit/diff context only"
+	}
+	artDir := filepath.Join(workDir, AgentArtifactsDir, PrePrReviewArtifactsRoot, runID)
+	st, err := os.Stat(artDir)
+	if err != nil || !st.IsDir() {
+		return PRPromptPrePRReviewHandoff{}, fmt.Sprintf("pre-pr-review: run directory for id %q is missing — PR prompt will use commit/diff context only", runID)
+	}
+
+	paths := collectPrePRArtifactRelPaths(artDir, runID)
+	var pathSB strings.Builder
+	for _, p := range paths {
+		fmt.Fprintf(&pathSB, "- `%s`\n", p)
+	}
+
+	var warnings []string
+	if _, err := os.Stat(filepath.Join(artDir, "handoff.json")); err != nil {
+		warnings = append(warnings, "handoff.json missing under latest pre-pr-review run (summaries may be incomplete)")
+	}
+	if _, err := os.Stat(filepath.Join(artDir, "pass-3.json")); err != nil {
+		warnings = append(warnings, "pass-3.json missing under latest pre-pr-review run")
+	}
+
+	return PRPromptPrePRReviewHandoff{
+		Present:       true,
+		Summary:       buildPRPromptHandoffSummaryMarkdown(artDir, runID),
+		ArtifactPaths: strings.TrimSpace(pathSB.String()),
+	}, strings.Join(warnings, "; ")
 }

--- a/internal/jrdev/pre_pr_review.go
+++ b/internal/jrdev/pre_pr_review.go
@@ -18,6 +18,7 @@ const (
 	prePRReviewMaxCycles  = 3
 	pass2HandoffFenceTag  = "jrdev-pre-pr-review-handoff"
 	pass3ArtifactFenceTag = "jrdev-pre-pr-review-pass3"
+	pass5HandoffFenceTag  = "jrdev-pre-pr-review-pass5-handoff"
 )
 
 // PrePRPass2Handoff is the JSON inside the pass-2 handoff fence (GM-012 / session handoff).
@@ -39,6 +40,42 @@ type PrePRSessionHandoff struct {
 	ConflictNotes string `json:"conflictNotes"`
 	FinalRound    int    `json:"finalRound"`
 	MatrixHadGaps bool   `json:"matrixHadGapsAtEnd"`
+	// Pass5BadTestByDesign and Pass5OperatorNotes may be merged after Pass 5 (optional fence in agent output).
+	Pass5BadTestByDesign string `json:"pass5BadTestByDesign,omitempty"`
+	Pass5OperatorNotes   string `json:"pass5OperatorNotes,omitempty"`
+}
+
+// PrePRPass5Handoff is optional JSON inside the pass-5 handoff fence (GM-010).
+type PrePRPass5Handoff struct {
+	BadTestByDesign string `json:"badTestByDesign"`
+	OperatorNotes   string `json:"operatorNotes"`
+}
+
+type prePRPass4ArtifactAttempt struct {
+	Attempt     int               `json:"attempt"`
+	Success     bool              `json:"success"`
+	Fingerprint string            `json:"fingerprint,omitempty"`
+	Steps       []Pass4StepRecord `json:"steps"`
+	FailedStep  *Pass4StepRecord  `json:"failedStep,omitempty"`
+}
+
+type prePRPass4ArtifactFile struct {
+	Attempts             []prePRPass4ArtifactAttempt `json:"attempts"`
+	FinalPass4Success    bool                        `json:"finalPass4Success"`
+	Pass5BudgetExhausted bool                        `json:"pass5BudgetExhausted,omitempty"`
+}
+
+type prePRPass5RoundRecord struct {
+	Round             int    `json:"round"`
+	Fingerprint       string `json:"fingerprint"`
+	FailingKind       string `json:"failingKind"`
+	FailingCommand    string `json:"failingCommand"`
+	HandoffFenceInner string `json:"pass5HandoffFenceInner,omitempty"`
+	HandoffParseError string `json:"pass5HandoffParseError,omitempty"`
+}
+
+type prePRPass5ArtifactFile struct {
+	Rounds []prePRPass5RoundRecord `json:"rounds"`
 }
 
 // PrePRPass3Artifact is the JSON inside the pass-3 artifact fence (GM-008).
@@ -194,6 +231,205 @@ func readBonusSteeringNote() (string, error) {
 	return PrePRReviewBonusCycleSteeringNonInteractive, nil
 }
 
+func readPass5BonusSteeringNote() (string, error) {
+	if StdinIsInteractive() {
+		fmt.Fprintf(os.Stderr, "jrdev: pre-pr-review: checks still failing after 3 Pass 5 rounds on the same fingerprint — enter a short steering note for one bonus Pass 5 round: ")
+		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(line), nil
+	}
+	return PrePRReviewPass5BonusCycleSteeringNonInteractive, nil
+}
+
+func parsePass5HandoffOptional(agentOut string) (h PrePRPass5Handoff, rawInner string, parseErr string) {
+	if !strings.Contains(agentOut, pass5HandoffFenceTag) {
+		return PrePRPass5Handoff{}, "", ""
+	}
+	inner, err := ExtractSingleMarkdownFence(pass5HandoffFenceTag, agentOut)
+	if err != nil {
+		return PrePRPass5Handoff{}, "", err.Error()
+	}
+	rawInner = inner
+	var hh PrePRPass5Handoff
+	if err := json.Unmarshal([]byte(inner), &hh); err != nil {
+		return PrePRPass5Handoff{}, rawInner, err.Error()
+	}
+	return hh, rawInner, ""
+}
+
+func mergePass5HandoffIntoSessionFile(path string, h PrePRPass5Handoff) error {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	var sess PrePRSessionHandoff
+	if err := json.Unmarshal(raw, &sess); err != nil {
+		return fmt.Errorf("handoff.json: %w", err)
+	}
+	if t := strings.TrimSpace(h.BadTestByDesign); t != "" {
+		sess.Pass5BadTestByDesign = t
+	}
+	if t := strings.TrimSpace(h.OperatorNotes); t != "" {
+		sess.Pass5OperatorNotes = t
+	}
+	out, err := json.MarshalIndent(sess, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0o644)
+}
+
+func writePrePRPass4Artifact(artDir string, attempts []prePRPass4ArtifactAttempt, finalSuccess, budgetExhausted bool) error {
+	wrap := prePRPass4ArtifactFile{
+		Attempts:             attempts,
+		FinalPass4Success:    finalSuccess,
+		Pass5BudgetExhausted: budgetExhausted,
+	}
+	b, err := json.MarshalIndent(wrap, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(artDir, "pass-4.json"), b, 0o644)
+}
+
+func writePrePRPass5Artifact(artDir string, rounds []prePRPass5RoundRecord) error {
+	if rounds == nil {
+		rounds = []prePRPass5RoundRecord{}
+	}
+	wrap := prePRPass5ArtifactFile{Rounds: rounds}
+	b, err := json.MarshalIndent(wrap, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(artDir, "pass-5.json"), b, 0o644)
+}
+
+func runPrePRPass4And5(cfg Config, prompts PromptBundle, agent AgentRunner, workDir, artDir, branch, integrationBase string, issueNums []int, agentPrint bool, log func(string, ...any)) error {
+	if strings.TrimSpace(prompts.PrePRReviewPass5) == "" {
+		return fmt.Errorf("jrdev: embedded pre-pr-review pass 5 prompt is empty")
+	}
+	handoffPath := filepath.Join(artDir, "handoff.json")
+	plan := BuildPass4CheckPlan(cfg.Project)
+
+	var pass4Attempts []prePRPass4ArtifactAttempt
+	var pass5Rounds []prePRPass5RoundRecord
+
+	activeFP := ""
+	pass5RoundForFP := 0
+	bonusNote := ""
+
+	for attempt := 1; ; attempt++ {
+		outcome := RunPass4Checks(workDir, plan)
+		fp := ""
+		if !outcome.Success && outcome.FailedStep != nil {
+			fp = Pass4FailureFingerprint(outcome.FailedStep.Kind, outcome.FailedStep.Output)
+		}
+
+		arec := prePRPass4ArtifactAttempt{Attempt: attempt, Success: outcome.Success, Steps: outcome.Steps}
+		if outcome.FailedStep != nil {
+			fs := *outcome.FailedStep
+			arec.FailedStep = &fs
+			arec.Fingerprint = fp
+		}
+		pass4Attempts = append(pass4Attempts, arec)
+
+		if outcome.Success {
+			if err := writePrePRPass4Artifact(artDir, pass4Attempts, true, false); err != nil {
+				return err
+			}
+			if err := writePrePRPass5Artifact(artDir, pass5Rounds); err != nil {
+				return err
+			}
+			log("jrdev: pre-pr-review: Pass 4 checks passed\n")
+			return nil
+		}
+
+		if outcome.FailedStep == nil {
+			return fmt.Errorf("jrdev: pre-pr-review Pass 4: failure with no failed step recorded")
+		}
+
+		if fp != activeFP {
+			activeFP = fp
+			pass5RoundForFP = 0
+			bonusNote = ""
+		}
+		pass5RoundForFP++
+		if pass5RoundForFP > prePRPass5MaxRounds {
+			log("jrdev: pre-pr-review: Pass 5 budget exhausted for this failure fingerprint (GM-010); leaving checks red (GM-014)\n")
+			if err := writePrePRPass4Artifact(artDir, pass4Attempts, false, true); err != nil {
+				return err
+			}
+			if err := writePrePRPass5Artifact(artDir, pass5Rounds); err != nil {
+				return err
+			}
+			return nil
+		}
+		if pass5RoundForFP == prePRPass5MaxRounds {
+			n, err := readPass5BonusSteeringNote()
+			if err != nil {
+				return err
+			}
+			bonusNote = n
+		} else {
+			bonusNote = ""
+		}
+
+		pass5Body, err := Render("pre-pr-review pass5", prompts.PrePRReviewPass5, PrePRReviewPass5PromptData{
+			IntegrationBranch:   branch,
+			IntegrationBase:     integrationBase,
+			IssueNumbers:        issueNums,
+			FailingKind:         string(outcome.FailedStep.Kind),
+			FailingCommand:      outcome.FailedStep.Command,
+			CapturedLogs:        outcome.FailedStep.Output,
+			NonInteractive:      !StdinIsInteractive(),
+			BonusSteeringNote:   bonusNote,
+			Pass5Round:          pass5RoundForFP,
+			Fingerprint:         fp,
+		})
+		if err != nil {
+			return err
+		}
+		pass5Out, err := runAgentUntilComplete(cfg, agent, log, "pre-pr-review pass5", workDir, func() (string, error) {
+			return pass5Body, nil
+		}, agentPrint)
+		if err != nil {
+			return err
+		}
+		h, rawH, hErr := parsePass5HandoffOptional(pass5Out)
+		p5rec := prePRPass5RoundRecord{
+			Round:             pass5RoundForFP,
+			Fingerprint:       fp,
+			FailingKind:       string(outcome.FailedStep.Kind),
+			FailingCommand:    outcome.FailedStep.Command,
+			HandoffParseError: hErr,
+		}
+		if hErr != "" && rawH != "" {
+			p5rec.HandoffFenceInner = rawH
+		}
+		pass5Rounds = append(pass5Rounds, p5rec)
+
+		if hErr == "" && (strings.TrimSpace(h.BadTestByDesign) != "" || strings.TrimSpace(h.OperatorNotes) != "") {
+			if err := mergePass5HandoffIntoSessionFile(handoffPath, h); err != nil {
+				return err
+			}
+		}
+
+		if err := writePrePRPass4Artifact(artDir, pass4Attempts, false, false); err != nil {
+			return err
+		}
+		if err := writePrePRPass5Artifact(artDir, pass5Rounds); err != nil {
+			return err
+		}
+
+		if err := RequireGitWorkingTreeClean(workDir); err != nil {
+			return err
+		}
+		log("jrdev: pre-pr-review: Pass 5 round %d complete; re-running Pass 4\n", pass5RoundForFP)
+	}
+}
+
 func writePass2RoundArtifact(artDir string, round int, handoff PrePRPass2Handoff, rawFenceInner string, parseErr string) error {
 	type wrap struct {
 		Round        int               `json:"round"`
@@ -223,7 +459,7 @@ func mergeSessionHandoff(last PrePRPass2Handoff, finalRound int, matrixHadGaps b
 	}
 }
 
-// RunPrePrReview executes discovery, Pass 1 ↔ Pass 2 loops, Pass 3 test-design review, artifacts, and session handoff (GM-007, GM-008, GM-012, GM-014).
+// RunPrePrReview executes discovery, Pass 1 ↔ Pass 2 loops, Pass 3 test-design review, Pass 4 configured checks, and Pass 5 fix loop, with artifacts and session handoff (GM-007–GM-010, GM-012, GM-014).
 func RunPrePrReview(cfg Config, prompts PromptBundle, agent AgentRunner, workDir string, log func(string, ...any)) error {
 	if log == nil {
 		log = func(string, ...any) {}
@@ -504,6 +740,9 @@ finalize:
 	}
 	log("jrdev: pre-pr-review: Pass 3 artifact written (pass-3.json)\n")
 	if err := RequireGitWorkingTreeClean(workDir); err != nil {
+		return err
+	}
+	if err := runPrePRPass4And5(cfg, prompts, agent, workDir, artDir, branch, integrationBase, issueNums, agentPrint, log); err != nil {
 		return err
 	}
 	return nil

--- a/internal/jrdev/pre_pr_review.go
+++ b/internal/jrdev/pre_pr_review.go
@@ -244,11 +244,13 @@ func readPass5BonusSteeringNote() (string, error) {
 }
 
 func parsePass5HandoffOptional(agentOut string) (h PrePRPass5Handoff, rawInner string, parseErr string) {
-	if !strings.Contains(agentOut, pass5HandoffFenceTag) {
-		return PrePRPass5Handoff{}, "", ""
-	}
 	inner, err := ExtractSingleMarkdownFence(pass5HandoffFenceTag, agentOut)
 	if err != nil {
+		// Optional handoff: prose may mention the tag name without a real fence.
+		noFenceMsg := fmt.Sprintf("jrdev: no %q fenced code block in agent output", pass5HandoffFenceTag)
+		if err.Error() == noFenceMsg {
+			return PrePRPass5Handoff{}, "", ""
+		}
 		return PrePRPass5Handoff{}, "", err.Error()
 	}
 	rawInner = inner

--- a/internal/jrdev/pre_pr_review.go
+++ b/internal/jrdev/pre_pr_review.go
@@ -1,6 +1,7 @@
 package jrdev
 
 import (
+	"bufio"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -12,6 +13,32 @@ import (
 
 // PrePrReviewArtifactsRoot is the path segment under .jrdev for this workflow.
 const PrePrReviewArtifactsRoot = "pre-pr-review"
+
+const (
+	prePRReviewMaxCycles = 3
+	pass2HandoffFenceTag = "jrdev-pre-pr-review-handoff"
+)
+
+// PrePRPass2Handoff is the JSON inside the pass-2 handoff fence (GM-012 / session handoff).
+type PrePRPass2Handoff struct {
+	Round         int    `json:"round"`
+	GapSummary    string `json:"gapSummary"`
+	MatrixDelta   string `json:"matrixDelta"`
+	DraftPRTitle  string `json:"draftPRTitle"`
+	DraftPRBody   string `json:"draftPRBody"`
+	GapNotes      string `json:"gapNotes"`
+	ConflictNotes string `json:"conflictNotes"`
+}
+
+// PrePRSessionHandoff is written to handoff.json after Pass 1↔2 orchestration.
+type PrePRSessionHandoff struct {
+	DraftPRTitle  string `json:"draftPRTitle"`
+	DraftPRBody   string `json:"draftPRBody"`
+	GapNotes      string `json:"gapNotes"`
+	ConflictNotes string `json:"conflictNotes"`
+	FinalRound    int    `json:"finalRound"`
+	MatrixHadGaps bool   `json:"matrixHadGapsAtEnd"`
+}
 
 func newPrePRRunID() (string, error) {
 	var b [4]byte
@@ -60,13 +87,110 @@ func DiscoverPrePrReviewIssueNumbers(cfg Config, workDir string) (nums []int, in
 	return UnionSortedInts(fromLog, fromPR), base, nil
 }
 
-// RunPrePrReview executes discovery, Pass 1 agent, matrix validation/repair, and artifacts (GM-013–GM-014).
+func roundPass1Path(artDir string, round int) string {
+	return filepath.Join(artDir, fmt.Sprintf("round-%02d-pass-1.json", round))
+}
+
+func roundPass2Path(artDir string, round int) string {
+	return filepath.Join(artDir, fmt.Sprintf("round-%02d-pass-2.json", round))
+}
+
+func formatPriorPassArtifacts(artDir string, maxRound int) (string, error) {
+	if maxRound < 1 {
+		return "(none — first round)", nil
+	}
+	var sb strings.Builder
+	for r := 1; r <= maxRound; r++ {
+		p1 := roundPass1Path(artDir, r)
+		b1, err := os.ReadFile(p1)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", err
+		}
+		fmt.Fprintf(&sb, "### Round %d — Pass 1 matrix (`round-%02d-pass-1.json`)\n\n```json\n%s\n```\n\n", r, r, strings.TrimSpace(string(b1)))
+		p2 := roundPass2Path(artDir, r)
+		b2, err := os.ReadFile(p2)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", err
+		}
+		fmt.Fprintf(&sb, "### Round %d — Pass 2 artifact (`round-%02d-pass-2.json`)\n\n```json\n%s\n```\n\n", r, r, strings.TrimSpace(string(b2)))
+	}
+	s := strings.TrimSpace(sb.String())
+	if s == "" {
+		return "(prior artifact files not found)", nil
+	}
+	return s, nil
+}
+
+func parsePass2Handoff(agentOut string) (h PrePRPass2Handoff, rawInner string, parseErr string) {
+	inner, err := ExtractSingleMarkdownFence(pass2HandoffFenceTag, agentOut)
+	if err != nil {
+		return PrePRPass2Handoff{}, "", err.Error()
+	}
+	rawInner = inner
+	var hh PrePRPass2Handoff
+	if err := json.Unmarshal([]byte(inner), &hh); err != nil {
+		return PrePRPass2Handoff{}, rawInner, err.Error()
+	}
+	return hh, rawInner, ""
+}
+
+func readBonusSteeringNote() (string, error) {
+	if StdinIsInteractive() {
+		fmt.Fprintf(os.Stderr, "jrdev: pre-pr-review: matrix still has gaps after %d cycles — enter a short steering note for one bonus Pass 1→2 cycle: ", prePRReviewMaxCycles)
+		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(line), nil
+	}
+	return PrePRReviewBonusCycleSteeringNonInteractive, nil
+}
+
+func writePass2RoundArtifact(artDir string, round int, handoff PrePRPass2Handoff, rawFenceInner string, parseErr string) error {
+	type wrap struct {
+		Round         int             `json:"round"`
+		Handoff       PrePRPass2Handoff `json:"handoff"`
+		HandoffRaw    string          `json:"handoffFenceInner,omitempty"`
+		HandoffError  string          `json:"handoffParseError,omitempty"`
+	}
+	w := wrap{Round: round, Handoff: handoff, HandoffRaw: rawFenceInner, HandoffError: parseErr}
+	if parseErr == "" {
+		w.HandoffRaw = ""
+	}
+	b, err := json.MarshalIndent(w, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(roundPass2Path(artDir, round), b, 0o644)
+}
+
+func mergeSessionHandoff(last PrePRPass2Handoff, finalRound int, matrixHadGaps bool) PrePRSessionHandoff {
+	return PrePRSessionHandoff{
+		DraftPRTitle:  strings.TrimSpace(last.DraftPRTitle),
+		DraftPRBody:   strings.TrimSpace(last.DraftPRBody),
+		GapNotes:      strings.TrimSpace(last.GapNotes),
+		ConflictNotes: strings.TrimSpace(last.ConflictNotes),
+		FinalRound:    finalRound,
+		MatrixHadGaps: matrixHadGaps,
+	}
+}
+
+// RunPrePrReview executes discovery, Pass 1 ↔ Pass 2 loops, artifacts, and session handoff (GM-007, GM-012, GM-014).
 func RunPrePrReview(cfg Config, prompts PromptBundle, agent AgentRunner, workDir string, log func(string, ...any)) error {
 	if log == nil {
 		log = func(string, ...any) {}
 	}
 	if strings.TrimSpace(prompts.PrePRReviewPass1) == "" {
 		return fmt.Errorf("jrdev: embedded pre-pr-review pass 1 prompt is empty")
+	}
+	if strings.TrimSpace(prompts.PrePRReviewPass2) == "" {
+		return fmt.Errorf("jrdev: embedded pre-pr-review pass 2 prompt is empty")
 	}
 	workDir, err := filepath.Abs(workDir)
 	if err != nil {
@@ -104,62 +228,7 @@ func RunPrePrReview(cfg Config, prompts PromptBundle, agent AgentRunner, workDir
 	if err != nil {
 		return err
 	}
-	commitHist, err := CommitHistoryForPrompt(workDir)
-	if err != nil {
-		return err
-	}
-	diff, err := GitDiffForPromptFromBase(workDir, integrationBase)
-	if err != nil {
-		return err
-	}
 	proj := cfg.Project
-	pass1Data := PrePRReviewPass1PromptData{
-		IntegrationBranch: branch,
-		IntegrationBase:   integrationBase,
-		IssueNumbers:      issueNums,
-		IssuesMarkdown:    issuesMD,
-		CommitHistory:     commitHist,
-		GitDiff:           diff,
-		LintTests:         PromptLintTests(proj),
-		UnitTests:         PromptUnitTests(proj),
-		NonInteractive:    !StdinIsInteractive(),
-	}
-	pass1Body, err := Render("pre-pr-review pass1", prompts.PrePRReviewPass1, pass1Data)
-	if err != nil {
-		return err
-	}
-
-	agentPrint := !StdinIsInteractive() // GM-011: TTY uses interactive agent argv; headless uses -p
-	pass1Out, err := runAgentUntilComplete(cfg, agent, log, "pre-pr-review pass1", workDir, func() (string, error) {
-		return pass1Body, nil
-	}, agentPrint)
-	if err != nil {
-		return err
-	}
-
-	inner, err := ExtractSinglePRDMatrixFence(pass1Out)
-	if err != nil {
-		return fmt.Errorf("pre-pr-review pass1: %w", err)
-	}
-	doc, err := ValidatePRDMatrixJSON(inner)
-	if err != nil {
-		repairPrompt := PrePRMatrixRepairPrompt(inner, err.Error())
-		repairOut, rerr := runAgentUntilComplete(cfg, agent, log, "pre-pr-review matrix repair", workDir, func() (string, error) {
-			return repairPrompt, nil
-		}, agentPrint)
-		if rerr != nil {
-			return fmt.Errorf("pre-pr-review matrix repair: %w", rerr)
-		}
-		inner, err = ExtractSinglePRDMatrixFence(repairOut)
-		if err != nil {
-			return fmt.Errorf("pre-pr-review matrix repair output: %w", err)
-		}
-		doc, err = ValidatePRDMatrixJSON(inner)
-		if err != nil {
-			return fmt.Errorf("pre-pr-review matrix invalid after repair: %w", err)
-		}
-	}
-	rawJSON := inner
 
 	runID, err := newPrePRRunID()
 	if err != nil {
@@ -169,21 +238,183 @@ func RunPrePrReview(cfg Config, prompts PromptBundle, agent AgentRunner, workDir
 	if err := os.MkdirAll(artDir, 0o755); err != nil {
 		return err
 	}
-	payload, err := json.MarshalIndent(doc, "", "  ")
-	if err != nil {
-		return err
-	}
-	p1path := filepath.Join(artDir, "pass-1.json")
-	if err := os.WriteFile(p1path, payload, 0o644); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(artDir, "raw-matrix.json"), []byte(rawJSON), 0o644); err != nil {
-		return err
-	}
 	latestPath := filepath.Join(workDir, AgentArtifactsDir, PrePrReviewArtifactsRoot, "latest")
 	if err := os.WriteFile(latestPath, []byte(runID+"\n"), 0o644); err != nil {
 		return err
 	}
-	log("jrdev: pre-pr-review: wrote %s Pass 1 artifacts (runId=%s)\n", p1path, runID)
+
+	agentPrint := !StdinIsInteractive()
+	var lastHandoff PrePRPass2Handoff
+	finalRound := 0
+
+	execRound := func(round int, bonusSteering string) (PRDMatrixDoc, error) {
+		priorMD, err := formatPriorPassArtifacts(artDir, round-1)
+		if err != nil {
+			return PRDMatrixDoc{}, err
+		}
+		commitHist, err := CommitHistoryForPrompt(workDir)
+		if err != nil {
+			return PRDMatrixDoc{}, err
+		}
+		diff, err := GitDiffForPromptFromBase(workDir, integrationBase)
+		if err != nil {
+			return PRDMatrixDoc{}, err
+		}
+
+		pass1Data := PrePRReviewPass1PromptData{
+			IntegrationBranch:          branch,
+			IntegrationBase:            integrationBase,
+			IssueNumbers:               issueNums,
+			IssuesMarkdown:             issuesMD,
+			CommitHistory:              commitHist,
+			GitDiff:                    diff,
+			LintTests:                    PromptLintTests(proj),
+			UnitTests:                    PromptUnitTests(proj),
+			NonInteractive:             !StdinIsInteractive(),
+			PriorPassArtifactsMarkdown: priorMD,
+			BonusSteeringNote:          strings.TrimSpace(bonusSteering),
+			Round:                      round,
+		}
+		pass1Body, err := Render("pre-pr-review pass1", prompts.PrePRReviewPass1, pass1Data)
+		if err != nil {
+			return PRDMatrixDoc{}, err
+		}
+		pass1Out, err := runAgentUntilComplete(cfg, agent, log, "pre-pr-review pass1", workDir, func() (string, error) {
+			return pass1Body, nil
+		}, agentPrint)
+		if err != nil {
+			return PRDMatrixDoc{}, err
+		}
+
+		inner, err := ExtractSinglePRDMatrixFence(pass1Out)
+		if err != nil {
+			return PRDMatrixDoc{}, fmt.Errorf("pre-pr-review pass1: %w", err)
+		}
+		doc, err := ValidatePRDMatrixJSON(inner)
+		if err != nil {
+			repairPrompt := PrePRMatrixRepairPrompt(inner, err.Error())
+			repairOut, rerr := runAgentUntilComplete(cfg, agent, log, "pre-pr-review matrix repair", workDir, func() (string, error) {
+				return repairPrompt, nil
+			}, agentPrint)
+			if rerr != nil {
+				return PRDMatrixDoc{}, fmt.Errorf("pre-pr-review matrix repair: %w", rerr)
+			}
+			inner, err = ExtractSinglePRDMatrixFence(repairOut)
+			if err != nil {
+				return PRDMatrixDoc{}, fmt.Errorf("pre-pr-review matrix repair output: %w", err)
+			}
+			doc, err = ValidatePRDMatrixJSON(inner)
+			if err != nil {
+				return PRDMatrixDoc{}, fmt.Errorf("pre-pr-review matrix invalid after repair: %w", err)
+			}
+		}
+		rawJSON := inner
+		p1payload, err := json.MarshalIndent(doc, "", "  ")
+		if err != nil {
+			return PRDMatrixDoc{}, err
+		}
+		if err := os.WriteFile(roundPass1Path(artDir, round), p1payload, 0o644); err != nil {
+			return PRDMatrixDoc{}, err
+		}
+		if err := os.WriteFile(filepath.Join(artDir, "pass-1.json"), p1payload, 0o644); err != nil {
+			return PRDMatrixDoc{}, err
+		}
+		if err := os.WriteFile(filepath.Join(artDir, "raw-matrix.json"), []byte(rawJSON), 0o644); err != nil {
+			return PRDMatrixDoc{}, err
+		}
+		log("jrdev: pre-pr-review: round %d Pass 1 matrix written (runId=%s)\n", round, runID)
+
+		matrixPretty := string(p1payload)
+		p2prior, err := formatPriorPassArtifacts(artDir, round-1)
+		if err != nil {
+			return PRDMatrixDoc{}, err
+		}
+		// Pass 2 prompt includes current round's Pass 1 output in "prior" via CurrentPass1MatrixJSON only;
+		// still pass prior completed rounds for full history (without duplicating current pass-1 file which is not written yet in prior formatter for this round - actually round-XX-pass-1 was just written; formatPriorPassArtifacts(artDir, round-1) excludes current. Good.)
+		pass2Data := PrePRReviewPass2PromptData{
+			IntegrationBranch:          branch,
+			IntegrationBase:            integrationBase,
+			IssueNumbers:               issueNums,
+			IssuesMarkdown:             issuesMD,
+			CommitHistory:              commitHist,
+			GitDiff:                    diff,
+			LintTests:                    PromptLintTests(proj),
+			UnitTests:                    PromptUnitTests(proj),
+			NonInteractive:             !StdinIsInteractive(),
+			PriorPassArtifactsMarkdown: p2prior,
+			BonusSteeringNote:          strings.TrimSpace(bonusSteering),
+			Round:                      round,
+			CurrentPass1MatrixJSON:     matrixPretty,
+		}
+		pass2Body, err := Render("pre-pr-review pass2", prompts.PrePRReviewPass2, pass2Data)
+		if err != nil {
+			return PRDMatrixDoc{}, err
+		}
+		pass2Out, err := runAgentUntilComplete(cfg, agent, log, "pre-pr-review pass2", workDir, func() (string, error) {
+			return pass2Body, nil
+		}, agentPrint)
+		if err != nil {
+			return PRDMatrixDoc{}, err
+		}
+		h, rawInner, parseErr := parsePass2Handoff(pass2Out)
+		if parseErr != "" {
+			log("jrdev: pre-pr-review: round %d Pass 2 handoff: %s\n", round, parseErr)
+		}
+		if err := writePass2RoundArtifact(artDir, round, h, rawInner, parseErr); err != nil {
+			return PRDMatrixDoc{}, err
+		}
+		p2bytes, err := os.ReadFile(roundPass2Path(artDir, round))
+		if err != nil {
+			return PRDMatrixDoc{}, err
+		}
+		if err := os.WriteFile(filepath.Join(artDir, "pass-2.json"), p2bytes, 0o644); err != nil {
+			return PRDMatrixDoc{}, err
+		}
+		log("jrdev: pre-pr-review: round %d Pass 2 artifact written\n", round)
+
+		lastHandoff = h
+		finalRound = round
+
+		if err := RequireGitWorkingTreeClean(workDir); err != nil {
+			return PRDMatrixDoc{}, err
+		}
+		return doc, nil
+	}
+
+	var lastDoc PRDMatrixDoc
+	for round := 1; round <= prePRReviewMaxCycles; round++ {
+		var err error
+		lastDoc, err = execRound(round, "")
+		if err != nil {
+			return err
+		}
+		if !PRDMatrixDocHasGaps(lastDoc) {
+			goto finalize
+		}
+		log("jrdev: pre-pr-review: round %d — matrix still has gaps; continuing Pass 1→2 loop\n", round)
+	}
+
+	if PRDMatrixDocHasGaps(lastDoc) {
+		note, err := readBonusSteeringNote()
+		if err != nil {
+			return err
+		}
+		log("jrdev: pre-pr-review: bonus Pass 1→2 cycle (round %d)\n", prePRReviewMaxCycles+1)
+		lastDoc, err = execRound(prePRReviewMaxCycles+1, note)
+		if err != nil {
+			return err
+		}
+	}
+
+finalize:
+	session := mergeSessionHandoff(lastHandoff, finalRound, PRDMatrixDocHasGaps(lastDoc))
+	sb, err := json.MarshalIndent(session, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(artDir, "handoff.json"), sb, 0o644); err != nil {
+		return err
+	}
+	log("jrdev: pre-pr-review: session complete (runId=%s); wrote handoff.json and pass 1↔2 artifacts under %s\n", runID, artDir)
 	return nil
 }

--- a/internal/jrdev/pre_pr_review.go
+++ b/internal/jrdev/pre_pr_review.go
@@ -17,6 +17,7 @@ const PrePrReviewArtifactsRoot = "pre-pr-review"
 const (
 	prePRReviewMaxCycles = 3
 	pass2HandoffFenceTag = "jrdev-pre-pr-review-handoff"
+	pass3ArtifactFenceTag = "jrdev-pre-pr-review-pass3"
 )
 
 // PrePRPass2Handoff is the JSON inside the pass-2 handoff fence (GM-012 / session handoff).
@@ -38,6 +39,16 @@ type PrePRSessionHandoff struct {
 	ConflictNotes string `json:"conflictNotes"`
 	FinalRound    int    `json:"finalRound"`
 	MatrixHadGaps bool   `json:"matrixHadGapsAtEnd"`
+}
+
+// PrePRPass3Artifact is the JSON inside the pass-3 artifact fence (GM-008).
+type PrePRPass3Artifact struct {
+	Summary             string `json:"summary"`
+	TestDesign          string `json:"testDesign"`
+	Coverage            string `json:"coverage"`
+	PRDTestingAlignment string `json:"prdTestingAlignment"`
+	StrictnessInference string `json:"strictnessInference"`
+	FollowUps           string `json:"followUps"`
 }
 
 func newPrePRRunID() (string, error) {
@@ -140,6 +151,37 @@ func parsePass2Handoff(agentOut string) (h PrePRPass2Handoff, rawInner string, p
 	return hh, rawInner, ""
 }
 
+func parsePass3Artifact(agentOut string) (a PrePRPass3Artifact, rawInner string, parseErr string) {
+	inner, err := ExtractSingleMarkdownFence(pass3ArtifactFenceTag, agentOut)
+	if err != nil {
+		return PrePRPass3Artifact{}, "", err.Error()
+	}
+	rawInner = inner
+	var aa PrePRPass3Artifact
+	if err := json.Unmarshal([]byte(inner), &aa); err != nil {
+		return PrePRPass3Artifact{}, rawInner, err.Error()
+	}
+	return aa, rawInner, ""
+}
+
+func writePass3Artifact(artDir string, finalRound int, artifact PrePRPass3Artifact, rawFenceInner string, parseErr string) error {
+	type wrap struct {
+		FinalRound         int                `json:"finalRound"`
+		Artifact           PrePRPass3Artifact `json:"artifact"`
+		ArtifactRaw        string             `json:"artifactFenceInner,omitempty"`
+		ArtifactParseError string             `json:"artifactParseError,omitempty"`
+	}
+	w := wrap{FinalRound: finalRound, Artifact: artifact, ArtifactRaw: rawFenceInner, ArtifactParseError: parseErr}
+	if parseErr == "" {
+		w.ArtifactRaw = ""
+	}
+	b, err := json.MarshalIndent(w, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(artDir, "pass-3.json"), b, 0o644)
+}
+
 func readBonusSteeringNote() (string, error) {
 	if StdinIsInteractive() {
 		fmt.Fprintf(os.Stderr, "jrdev: pre-pr-review: matrix still has gaps after %d cycles — enter a short steering note for one bonus Pass 1→2 cycle: ", prePRReviewMaxCycles)
@@ -181,7 +223,7 @@ func mergeSessionHandoff(last PrePRPass2Handoff, finalRound int, matrixHadGaps b
 	}
 }
 
-// RunPrePrReview executes discovery, Pass 1 ↔ Pass 2 loops, artifacts, and session handoff (GM-007, GM-012, GM-014).
+// RunPrePrReview executes discovery, Pass 1 ↔ Pass 2 loops, Pass 3 test-design review, artifacts, and session handoff (GM-007, GM-008, GM-012, GM-014).
 func RunPrePrReview(cfg Config, prompts PromptBundle, agent AgentRunner, workDir string, log func(string, ...any)) error {
 	if log == nil {
 		log = func(string, ...any) {}
@@ -191,6 +233,9 @@ func RunPrePrReview(cfg Config, prompts PromptBundle, agent AgentRunner, workDir
 	}
 	if strings.TrimSpace(prompts.PrePRReviewPass2) == "" {
 		return fmt.Errorf("jrdev: embedded pre-pr-review pass 2 prompt is empty")
+	}
+	if strings.TrimSpace(prompts.PrePRReviewPass3) == "" {
+		return fmt.Errorf("jrdev: embedded pre-pr-review pass 3 prompt is empty")
 	}
 	workDir, err := filepath.Abs(workDir)
 	if err != nil {
@@ -415,5 +460,51 @@ finalize:
 		return err
 	}
 	log("jrdev: pre-pr-review: session complete (runId=%s); wrote handoff.json and pass 1↔2 artifacts under %s\n", runID, artDir)
+
+	priorAll, err := formatPriorPassArtifacts(artDir, finalRound)
+	if err != nil {
+		return err
+	}
+	commitHist3, err := CommitHistoryForPrompt(workDir)
+	if err != nil {
+		return err
+	}
+	diff3, err := GitDiffForPromptFromBase(workDir, integrationBase)
+	if err != nil {
+		return err
+	}
+	pass3Data := PrePRReviewPass3PromptData{
+		IntegrationBranch:          branch,
+		IntegrationBase:            integrationBase,
+		IssueNumbers:               issueNums,
+		IssuesMarkdown:             issuesMD,
+		CommitHistory:              commitHist3,
+		GitDiff:                    diff3,
+		NonInteractive:             !StdinIsInteractive(),
+		PriorPassArtifactsMarkdown: priorAll,
+		SessionHandoffJSON:         strings.TrimSpace(string(sb)),
+		FinalRound:                 finalRound,
+	}
+	pass3Body, err := Render("pre-pr-review pass3", prompts.PrePRReviewPass3, pass3Data)
+	if err != nil {
+		return err
+	}
+	pass3Out, err := runAgentUntilComplete(cfg, agent, log, "pre-pr-review pass3", workDir, func() (string, error) {
+		return pass3Body, nil
+	}, agentPrint)
+	if err != nil {
+		return err
+	}
+	p3, raw3, p3err := parsePass3Artifact(pass3Out)
+	if p3err != "" {
+		log("jrdev: pre-pr-review: Pass 3 artifact: %s\n", p3err)
+	}
+	if err := writePass3Artifact(artDir, finalRound, p3, raw3, p3err); err != nil {
+		return err
+	}
+	log("jrdev: pre-pr-review: Pass 3 artifact written (pass-3.json)\n")
+	if err := RequireGitWorkingTreeClean(workDir); err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/jrdev/pre_pr_review.go
+++ b/internal/jrdev/pre_pr_review.go
@@ -108,7 +108,7 @@ func RunPrePrReview(cfg Config, prompts PromptBundle, agent AgentRunner, workDir
 	if err != nil {
 		return err
 	}
-	diff, err := GitDiffForPrompt(workDir)
+	diff, err := GitDiffForPromptFromBase(workDir, integrationBase)
 	if err != nil {
 		return err
 	}
@@ -129,10 +129,10 @@ func RunPrePrReview(cfg Config, prompts PromptBundle, agent AgentRunner, workDir
 		return err
 	}
 
-	pass1Print := !StdinIsInteractive() // GM-011: TTY uses interactive agent argv; headless uses -p
+	agentPrint := !StdinIsInteractive() // GM-011: TTY uses interactive agent argv; headless uses -p
 	pass1Out, err := runAgentUntilComplete(cfg, agent, log, "pre-pr-review pass1", workDir, func() (string, error) {
 		return pass1Body, nil
-	}, pass1Print)
+	}, agentPrint)
 	if err != nil {
 		return err
 	}
@@ -146,7 +146,7 @@ func RunPrePrReview(cfg Config, prompts PromptBundle, agent AgentRunner, workDir
 		repairPrompt := PrePRMatrixRepairPrompt(inner, err.Error())
 		repairOut, rerr := runAgentUntilComplete(cfg, agent, log, "pre-pr-review matrix repair", workDir, func() (string, error) {
 			return repairPrompt, nil
-		}, true)
+		}, agentPrint)
 		if rerr != nil {
 			return fmt.Errorf("pre-pr-review matrix repair: %w", rerr)
 		}

--- a/internal/jrdev/pre_pr_review.go
+++ b/internal/jrdev/pre_pr_review.go
@@ -154,10 +154,10 @@ func readBonusSteeringNote() (string, error) {
 
 func writePass2RoundArtifact(artDir string, round int, handoff PrePRPass2Handoff, rawFenceInner string, parseErr string) error {
 	type wrap struct {
-		Round         int             `json:"round"`
-		Handoff       PrePRPass2Handoff `json:"handoff"`
-		HandoffRaw    string          `json:"handoffFenceInner,omitempty"`
-		HandoffError  string          `json:"handoffParseError,omitempty"`
+		Round        int               `json:"round"`
+		Handoff      PrePRPass2Handoff `json:"handoff"`
+		HandoffRaw   string            `json:"handoffFenceInner,omitempty"`
+		HandoffError string            `json:"handoffParseError,omitempty"`
 	}
 	w := wrap{Round: round, Handoff: handoff, HandoffRaw: rawFenceInner, HandoffError: parseErr}
 	if parseErr == "" {
@@ -329,8 +329,7 @@ func RunPrePrReview(cfg Config, prompts PromptBundle, agent AgentRunner, workDir
 		if err != nil {
 			return PRDMatrixDoc{}, err
 		}
-		// Pass 2 prompt includes current round's Pass 1 output in "prior" via CurrentPass1MatrixJSON only;
-		// still pass prior completed rounds for full history (without duplicating current pass-1 file which is not written yet in prior formatter for this round - actually round-XX-pass-1 was just written; formatPriorPassArtifacts(artDir, round-1) excludes current. Good.)
+		// Prior rounds only; this round's matrix is CurrentPass1MatrixJSON (avoids duplicating round-N-pass-1.json).
 		pass2Data := PrePRReviewPass2PromptData{
 			IntegrationBranch:          branch,
 			IntegrationBase:            integrationBase,

--- a/internal/jrdev/pre_pr_review.go
+++ b/internal/jrdev/pre_pr_review.go
@@ -15,8 +15,8 @@ import (
 const PrePrReviewArtifactsRoot = "pre-pr-review"
 
 const (
-	prePRReviewMaxCycles = 3
-	pass2HandoffFenceTag = "jrdev-pre-pr-review-handoff"
+	prePRReviewMaxCycles  = 3
+	pass2HandoffFenceTag  = "jrdev-pre-pr-review-handoff"
 	pass3ArtifactFenceTag = "jrdev-pre-pr-review-pass3"
 )
 
@@ -313,8 +313,8 @@ func RunPrePrReview(cfg Config, prompts PromptBundle, agent AgentRunner, workDir
 			IssuesMarkdown:             issuesMD,
 			CommitHistory:              commitHist,
 			GitDiff:                    diff,
-			LintTests:                    PromptLintTests(proj),
-			UnitTests:                    PromptUnitTests(proj),
+			LintTests:                  PromptLintTests(proj),
+			UnitTests:                  PromptUnitTests(proj),
 			NonInteractive:             !StdinIsInteractive(),
 			PriorPassArtifactsMarkdown: priorMD,
 			BonusSteeringNote:          strings.TrimSpace(bonusSteering),
@@ -382,8 +382,8 @@ func RunPrePrReview(cfg Config, prompts PromptBundle, agent AgentRunner, workDir
 			IssuesMarkdown:             issuesMD,
 			CommitHistory:              commitHist,
 			GitDiff:                    diff,
-			LintTests:                    PromptLintTests(proj),
-			UnitTests:                    PromptUnitTests(proj),
+			LintTests:                  PromptLintTests(proj),
+			UnitTests:                  PromptUnitTests(proj),
 			NonInteractive:             !StdinIsInteractive(),
 			PriorPassArtifactsMarkdown: p2prior,
 			BonusSteeringNote:          strings.TrimSpace(bonusSteering),

--- a/internal/jrdev/pre_pr_review.go
+++ b/internal/jrdev/pre_pr_review.go
@@ -1,0 +1,189 @@
+package jrdev
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// PrePrReviewArtifactsRoot is the path segment under .jrdev for this workflow.
+const PrePrReviewArtifactsRoot = "pre-pr-review"
+
+func newPrePRRunID() (string, error) {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// FormatIssuesMarkdownForPass1 fetches bodies via gh and builds markdown sections.
+func FormatIssuesMarkdownForPass1(cfg Config, issueNums []int) (string, error) {
+	var sb strings.Builder
+	for _, n := range issueNums {
+		body, err := IssueBody(cfg, n)
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintf(&sb, "#### Issue #%d\n\n%s\n\n", n, strings.TrimSpace(body))
+	}
+	return strings.TrimSpace(sb.String()), nil
+}
+
+// DiscoverPrePrReviewIssueNumbers returns the union (GM-002) of issue IDs from git log
+// integrationBase..HEAD and from gh pr view closing references when a PR exists.
+func DiscoverPrePrReviewIssueNumbers(cfg Config, workDir string) (nums []int, integrationBase string, err error) {
+	workDir, err = filepath.Abs(workDir)
+	if err != nil {
+		return nil, "", err
+	}
+	base := strings.TrimSpace(cfg.Integration)
+	if base == "" {
+		base = "origin/main"
+	}
+	fromLog, err := ParseIssueRefsFromGitLogRange(workDir, base)
+	if err != nil {
+		return nil, base, err
+	}
+	headBranch, err := GitCurrentBranch(workDir)
+	if err != nil {
+		return nil, base, err
+	}
+	fromPR, err := PRClosingIssueNumbersFromGH(cfg, headBranch)
+	if err != nil {
+		return nil, base, err
+	}
+	return UnionSortedInts(fromLog, fromPR), base, nil
+}
+
+// RunPrePrReview executes discovery, Pass 1 agent, matrix validation/repair, and artifacts (GM-013–GM-014).
+func RunPrePrReview(cfg Config, prompts PromptBundle, agent AgentRunner, workDir string, log func(string, ...any)) error {
+	if log == nil {
+		log = func(string, ...any) {}
+	}
+	if strings.TrimSpace(prompts.PrePRReviewPass1) == "" {
+		return fmt.Errorf("jrdev: embedded pre-pr-review pass 1 prompt is empty")
+	}
+	workDir, err := filepath.Abs(workDir)
+	if err != nil {
+		return err
+	}
+
+	git := GitOps{RepoRoot: cfg.RepoRoot}
+	if cfg.Verbose {
+		git.Log = log
+	}
+	vlog(cfg, log, "jrdev: verbose: pre-pr-review — git fetch origin\n")
+	if err := git.FetchOrigin(); err != nil {
+		return err
+	}
+
+	issueNums, integrationBase, err := DiscoverPrePrReviewIssueNumbers(cfg, workDir)
+	if err != nil {
+		return err
+	}
+	if len(issueNums) == 0 {
+		return fmt.Errorf("jrdev pre-pr-review: no linked GitHub issues found — add Fixes/Closes/Resolves #<n> to commits in %s..HEAD and/or ensure the branch has a GitHub PR with closing issue references", integrationBase)
+	}
+	log("jrdev: pre-pr-review: discovered issues %v (integration base %q)\n", issueNums, integrationBase)
+
+	vlog(cfg, log, "jrdev: verbose: pre-pr-review — preflight\n")
+	if err := RunPreflight(cfg, agent, log); err != nil {
+		return err
+	}
+
+	branch, err := GitCurrentBranch(workDir)
+	if err != nil {
+		return err
+	}
+	issuesMD, err := FormatIssuesMarkdownForPass1(cfg, issueNums)
+	if err != nil {
+		return err
+	}
+	commitHist, err := CommitHistoryForPrompt(workDir)
+	if err != nil {
+		return err
+	}
+	diff, err := GitDiffForPrompt(workDir)
+	if err != nil {
+		return err
+	}
+	proj := cfg.Project
+	pass1Data := PrePRReviewPass1PromptData{
+		IntegrationBranch: branch,
+		IntegrationBase:   integrationBase,
+		IssueNumbers:      issueNums,
+		IssuesMarkdown:    issuesMD,
+		CommitHistory:     commitHist,
+		GitDiff:           diff,
+		LintTests:         PromptLintTests(proj),
+		UnitTests:         PromptUnitTests(proj),
+		NonInteractive:    !StdinIsInteractive(),
+	}
+	pass1Body, err := Render("pre-pr-review pass1", prompts.PrePRReviewPass1, pass1Data)
+	if err != nil {
+		return err
+	}
+
+	pass1Print := !StdinIsInteractive() // GM-011: TTY uses interactive agent argv; headless uses -p
+	pass1Out, err := runAgentUntilComplete(cfg, agent, log, "pre-pr-review pass1", workDir, func() (string, error) {
+		return pass1Body, nil
+	}, pass1Print)
+	if err != nil {
+		return err
+	}
+
+	inner, err := ExtractSinglePRDMatrixFence(pass1Out)
+	if err != nil {
+		return fmt.Errorf("pre-pr-review pass1: %w", err)
+	}
+	doc, err := ValidatePRDMatrixJSON(inner)
+	if err != nil {
+		repairPrompt := PrePRMatrixRepairPrompt(inner, err.Error())
+		repairOut, rerr := runAgentUntilComplete(cfg, agent, log, "pre-pr-review matrix repair", workDir, func() (string, error) {
+			return repairPrompt, nil
+		}, true)
+		if rerr != nil {
+			return fmt.Errorf("pre-pr-review matrix repair: %w", rerr)
+		}
+		inner, err = ExtractSinglePRDMatrixFence(repairOut)
+		if err != nil {
+			return fmt.Errorf("pre-pr-review matrix repair output: %w", err)
+		}
+		doc, err = ValidatePRDMatrixJSON(inner)
+		if err != nil {
+			return fmt.Errorf("pre-pr-review matrix invalid after repair: %w", err)
+		}
+	}
+	rawJSON := inner
+
+	runID, err := newPrePRRunID()
+	if err != nil {
+		return err
+	}
+	artDir := filepath.Join(workDir, AgentArtifactsDir, PrePrReviewArtifactsRoot, runID)
+	if err := os.MkdirAll(artDir, 0o755); err != nil {
+		return err
+	}
+	payload, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	p1path := filepath.Join(artDir, "pass-1.json")
+	if err := os.WriteFile(p1path, payload, 0o644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(artDir, "raw-matrix.json"), []byte(rawJSON), 0o644); err != nil {
+		return err
+	}
+	latestPath := filepath.Join(workDir, AgentArtifactsDir, PrePrReviewArtifactsRoot, "latest")
+	if err := os.WriteFile(latestPath, []byte(runID+"\n"), 0o644); err != nil {
+		return err
+	}
+	log("jrdev: pre-pr-review: wrote %s Pass 1 artifacts (runId=%s)\n", p1path, runID)
+	return nil
+}

--- a/internal/jrdev/pre_pr_review_pass4.go
+++ b/internal/jrdev/pre_pr_review_pass4.go
@@ -1,0 +1,181 @@
+package jrdev
+
+import (
+	"errors"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+// Pass4CheckKind identifies which config list a command came from (GM-009).
+type Pass4CheckKind string
+
+const (
+	Pass4Lint          Pass4CheckKind = "lint"
+	Pass4Unit          Pass4CheckKind = "unit"
+	Pass4Integration   Pass4CheckKind = "integration"
+	prePRPass5MaxRounds               = 4 // 3 regular + 1 bonus per stable fingerprint (GM-010)
+)
+
+// Pass4PlannedCheck is one shell command jrdev will run in Pass 4 order.
+type Pass4PlannedCheck struct {
+	Kind    Pass4CheckKind
+	Command string
+}
+
+// BuildPass4CheckPlan returns lint → unit → integration commands (GM-009).
+func BuildPass4CheckPlan(p ProjectConfig) []Pass4PlannedCheck {
+	var plan []Pass4PlannedCheck
+	for _, c := range p.Lint {
+		cc := strings.TrimSpace(c)
+		if cc == "" {
+			continue
+		}
+		plan = append(plan, Pass4PlannedCheck{Kind: Pass4Lint, Command: c})
+	}
+	for _, c := range p.Unit {
+		cc := strings.TrimSpace(c)
+		if cc == "" {
+			continue
+		}
+		plan = append(plan, Pass4PlannedCheck{Kind: Pass4Unit, Command: c})
+	}
+	for _, c := range p.Integration {
+		cc := strings.TrimSpace(c)
+		if cc == "" {
+			continue
+		}
+		plan = append(plan, Pass4PlannedCheck{Kind: Pass4Integration, Command: c})
+	}
+	return plan
+}
+
+// Pass4StepRecord is one executed check (GM-009).
+type Pass4StepRecord struct {
+	Kind     Pass4CheckKind `json:"kind"`
+	Command  string         `json:"command"`
+	ExitCode int            `json:"exitCode"`
+	Success  bool           `json:"success"`
+	// Output is omitted or truncated for successful steps to keep artifacts small.
+	Output string `json:"output,omitempty"`
+}
+
+// Pass4RunOutcome is the result of one full Pass 4 invocation (all checks or stop at first failure).
+type Pass4RunOutcome struct {
+	Success bool
+	Steps   []Pass4StepRecord
+	// FailedStep is set when Success is false (first failing command).
+	FailedStep *Pass4StepRecord
+}
+
+// RunPass4Checks runs planned checks in order, stopping at the first failure (GM-009).
+func RunPass4Checks(workDir string, plan []Pass4PlannedCheck) Pass4RunOutcome {
+	if len(plan) == 0 {
+		return Pass4RunOutcome{Success: true, Steps: nil, FailedStep: nil}
+	}
+	var steps []Pass4StepRecord
+	for _, item := range plan {
+		out, code, err := runProjectShellCommand(workDir, item.Command)
+		s := string(out)
+		if err != nil && !errors.Is(err, errExit) {
+			rec := Pass4StepRecord{
+				Kind:     item.Kind,
+				Command:  item.Command,
+				ExitCode: code,
+				Success:  false,
+				Output:   strings.TrimSpace(s),
+			}
+			if rec.Output == "" {
+				rec.Output = err.Error()
+			} else {
+				rec.Output = rec.Output + "\n" + err.Error()
+			}
+			steps = append(steps, rec)
+			r := rec
+			return Pass4RunOutcome{Success: false, Steps: steps, FailedStep: &r}
+		}
+		if code != 0 {
+			rec := Pass4StepRecord{
+				Kind:     item.Kind,
+				Command:  item.Command,
+				ExitCode: code,
+				Success:  false,
+				Output:   s,
+			}
+			steps = append(steps, rec)
+			r := rec
+			return Pass4RunOutcome{Success: false, Steps: steps, FailedStep: &r}
+		}
+		rec := Pass4StepRecord{
+			Kind:     item.Kind,
+			Command:  item.Command,
+			ExitCode: code,
+			Success:  true,
+			Output:   truncatePass4Output(s, true),
+		}
+		steps = append(steps, rec)
+	}
+	return Pass4RunOutcome{Success: true, Steps: steps, FailedStep: nil}
+}
+
+var errExit = errors.New("non-zero exit")
+
+func truncatePass4Output(s string, success bool) string {
+	const maxSuccess = 2048
+	if !success {
+		return s
+	}
+	s = strings.TrimSpace(s)
+	if len(s) <= maxSuccess {
+		return s
+	}
+	return s[:maxSuccess] + "\n…(truncated)"
+}
+
+// runProjectShellCommand runs one config line via the system shell (sh -c / cmd /C).
+func runProjectShellCommand(workDir, line string) ([]byte, int, error) {
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/C", line)
+	} else {
+		cmd = exec.Command("sh", "-c", line)
+	}
+	cmd.Dir = workDir
+	out, err := cmd.CombinedOutput()
+	code := 0
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			code = ee.ExitCode()
+			return out, code, errExit
+		}
+		return out, -1, err
+	}
+	return out, code, nil
+}
+
+var (
+	reISO8601Loose = regexp.MustCompile(`\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?`)
+	reDateYMD      = regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}\b`)
+	reClock        = regexp.MustCompile(`\b\d{1,2}:\d{2}:\d{2}(?:\.\d+)?\b`)
+	reGoTestTime   = regexp.MustCompile(`\(\d+(?:\.\d+)?s\)`)
+)
+
+// NormalizeCheckFailureKey strips volatile timestamps and condenses whitespace for stable fingerprints (GM-010).
+func NormalizeCheckFailureKey(combinedLog string) string {
+	s := combinedLog
+	s = reISO8601Loose.ReplaceAllString(s, "<ts>")
+	s = reDateYMD.ReplaceAllString(s, "<date>")
+	s = reClock.ReplaceAllString(s, "<clock>")
+	s = reGoTestTime.ReplaceAllString(s, "(<dur>)")
+	// Elapsed / cache lines in go test
+	s = regexp.MustCompile(`(?m)^ok\s+\S+\s+\d+\.\d+s\s*$`).ReplaceAllString(s, "ok <pkg> <dur>s")
+	s = regexp.MustCompile(`\s+`).ReplaceAllString(s, " ")
+	return strings.TrimSpace(s)
+}
+
+// Pass4FailureFingerprint combines command kind and normalized log text (GM-010).
+func Pass4FailureFingerprint(kind Pass4CheckKind, failedStepOutput string) string {
+	return string(kind) + "\x1e" + NormalizeCheckFailureKey(failedStepOutput)
+}

--- a/internal/jrdev/pre_pr_review_pass4_test.go
+++ b/internal/jrdev/pre_pr_review_pass4_test.go
@@ -51,6 +51,43 @@ func TestPass4FailureFingerprint_includesKind(t *testing.T) {
 	}
 }
 
+func TestPass4FailureFingerprint_kindSeparatesSameLog(t *testing.T) {
+	log := "FAIL same error line"
+	lint := Pass4FailureFingerprint(Pass4Lint, log)
+	unit := Pass4FailureFingerprint(Pass4Unit, log)
+	if lint == unit {
+		t.Fatalf("expected different fingerprints for different kinds: %q", lint)
+	}
+}
+
+func TestNormalizeCheckFailureKey_empty(t *testing.T) {
+	if got := NormalizeCheckFailureKey(""); got != "" {
+		t.Fatalf("got %q", got)
+	}
+	if got := NormalizeCheckFailureKey("   \n\t  "); got != "" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestTruncatePass4Output_longSuccessTruncates(t *testing.T) {
+	const n = 2500
+	s := strings.Repeat("x", n)
+	got := truncatePass4Output(s, true)
+	if !strings.HasSuffix(got, "\n…(truncated)") {
+		t.Fatalf("missing suffix: len=%d", len(got))
+	}
+	if len(got) != 2048+len("\n…(truncated)") {
+		t.Fatalf("len=%d want %d", len(got), 2048+len("\n…(truncated)"))
+	}
+}
+
+func TestTruncatePass4Output_failureNotTruncated(t *testing.T) {
+	s := strings.Repeat("e", 5000)
+	if got := truncatePass4Output(s, false); got != s {
+		t.Fatalf("expected raw failure log preserved")
+	}
+}
+
 func TestRunPass4Checks_emptyPlanSucceeds(t *testing.T) {
 	out := RunPass4Checks(t.TempDir(), nil)
 	if !out.Success || len(out.Steps) != 0 {

--- a/internal/jrdev/pre_pr_review_pass4_test.go
+++ b/internal/jrdev/pre_pr_review_pass4_test.go
@@ -1,0 +1,109 @@
+package jrdev
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBuildPass4CheckPlan_orderAndSkipEmpty(t *testing.T) {
+	p := ProjectConfig{
+		Lint:        []string{"lint-a", "  ", "lint-b"},
+		Unit:        []string{"unit-1"},
+		Integration: []string{"", "int-z"},
+	}
+	plan := BuildPass4CheckPlan(p)
+	if len(plan) != 4 {
+		t.Fatalf("len=%d %#v", len(plan), plan)
+	}
+	want := []Pass4PlannedCheck{
+		{Kind: Pass4Lint, Command: "lint-a"},
+		{Kind: Pass4Lint, Command: "lint-b"},
+		{Kind: Pass4Unit, Command: "unit-1"},
+		{Kind: Pass4Integration, Command: "int-z"},
+	}
+	for i := range plan {
+		if plan[i].Kind != want[i].Kind || plan[i].Command != want[i].Command {
+			t.Fatalf("i=%d got %#v want %#v", i, plan[i], want[i])
+		}
+	}
+}
+
+func TestNormalizeCheckFailureKey_timestampsAndWhitespace(t *testing.T) {
+	raw := "2026-04-02T15:04:05Z boom\nfail at 2026-04-02\n12:34:56  ok	\n(1.23s) (44.00s)"
+	got := NormalizeCheckFailureKey(raw)
+	for _, w := range []string{"<ts>", "<date>", "<clock>", "<dur>"} {
+		if !strings.Contains(got, w) {
+			t.Fatalf("missing %q in %q", w, got)
+		}
+	}
+	if strings.Contains(got, "2026") {
+		t.Fatalf("raw date leaked: %q", got)
+	}
+}
+
+func TestPass4FailureFingerprint_includesKind(t *testing.T) {
+	fp := Pass4FailureFingerprint(Pass4Lint, "error: same")
+	if !strings.HasPrefix(fp, "lint\x1e") {
+		t.Fatalf("got %q", fp)
+	}
+}
+
+func TestRunPass4Checks_emptyPlanSucceeds(t *testing.T) {
+	out := RunPass4Checks(t.TempDir(), nil)
+	if !out.Success || len(out.Steps) != 0 {
+		t.Fatalf("%+v", out)
+	}
+}
+
+func TestRunPass4Checks_stopsOnFirstFailure(t *testing.T) {
+	tmp := t.TempDir()
+	var failLine, okLine string
+	if runtime.GOOS == "windows" {
+		failLine = "cmd /C exit /b 1"
+		okLine = "cmd /C echo second-should-not-run"
+	} else {
+		failLine = "false"
+		okLine = "echo second-should-not-run"
+	}
+	plan := []Pass4PlannedCheck{
+		{Kind: Pass4Lint, Command: failLine},
+		{Kind: Pass4Unit, Command: okLine},
+	}
+	out := RunPass4Checks(tmp, plan)
+	if out.Success {
+		t.Fatal("expected failure")
+	}
+	if len(out.Steps) != 1 {
+		t.Fatalf("steps=%d want 1 (stop early)", len(out.Steps))
+	}
+	if out.FailedStep == nil || out.FailedStep.Kind != Pass4Lint {
+		t.Fatalf("%+v", out.FailedStep)
+	}
+}
+
+func TestRunPass4Checks_runsEchoInOrder(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("trace file ordering test uses sh redirection")
+	}
+	tmp := t.TempDir()
+	trace := filepath.Join(tmp, "trace.txt")
+	plan := []Pass4PlannedCheck{
+		{Kind: Pass4Lint, Command: "sh -c 'echo L >> " + trace + "'"},
+		{Kind: Pass4Unit, Command: "sh -c 'echo U >> " + trace + "'"},
+		{Kind: Pass4Integration, Command: "sh -c 'echo I >> " + trace + "'"},
+	}
+	out := RunPass4Checks(tmp, plan)
+	if !out.Success || len(out.Steps) != 3 {
+		t.Fatalf("%+v", out)
+	}
+	b, err := os.ReadFile(trace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "L\nU\nI\n" {
+		t.Fatalf("trace=%q", b)
+	}
+}

--- a/internal/jrdev/pre_pr_review_test.go
+++ b/internal/jrdev/pre_pr_review_test.go
@@ -206,6 +206,51 @@ func TestWritePass3Artifact_parseErrorPreservesRaw(t *testing.T) {
 	}
 }
 
+func TestParsePass5HandoffOptional_absent(t *testing.T) {
+	h, raw, perr := parsePass5HandoffOptional("COMPLETE\nno fence")
+	if perr != "" || raw != "" || h != (PrePRPass5Handoff{}) {
+		t.Fatalf("h=%+v raw=%q perr=%q", h, raw, perr)
+	}
+}
+
+func TestParsePass5HandoffOptional_valid(t *testing.T) {
+	body := "```" + pass5HandoffFenceTag + "\n" + `{"badTestByDesign":"x","operatorNotes":"y"}` + "\n```\n"
+	h, raw, perr := parsePass5HandoffOptional(body)
+	if perr != "" {
+		t.Fatal(perr)
+	}
+	if h.BadTestByDesign != "x" || h.OperatorNotes != "y" || raw == "" {
+		t.Fatalf("%+v raw=%q", h, raw)
+	}
+}
+
+func TestMergePass5HandoffIntoSessionFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "handoff.json")
+	sess := PrePRSessionHandoff{DraftPRTitle: "t", FinalRound: 2, MatrixHadGaps: false}
+	b, err := json.MarshalIndent(sess, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := mergePass5HandoffIntoSessionFile(path, PrePRPass5Handoff{BadTestByDesign: "bad", OperatorNotes: "note"}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got PrePRSessionHandoff
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.DraftPRTitle != "t" || got.Pass5BadTestByDesign != "bad" || got.Pass5OperatorNotes != "note" {
+		t.Fatalf("%+v", got)
+	}
+}
+
 func TestMergeSessionHandoff_trimsAndFlags(t *testing.T) {
 	last := PrePRPass2Handoff{
 		DraftPRTitle:  "  t  ",

--- a/internal/jrdev/pre_pr_review_test.go
+++ b/internal/jrdev/pre_pr_review_test.go
@@ -1,6 +1,11 @@
 package jrdev
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestNewPrePRRunID_length(t *testing.T) {
 	id, err := newPrePRRunID()
@@ -14,5 +19,98 @@ func TestNewPrePRRunID_length(t *testing.T) {
 		if r < '0' || r > 'f' || (r > '9' && r < 'a') {
 			t.Fatalf("non-hex in %q", id)
 		}
+	}
+}
+
+func TestFormatPriorPassArtifacts_firstRound(t *testing.T) {
+	s, err := formatPriorPassArtifacts(t.TempDir(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != "(none — first round)" {
+		t.Fatalf("got %q", s)
+	}
+}
+
+func TestFormatPriorPassArtifacts_missingFiles(t *testing.T) {
+	s, err := formatPriorPassArtifacts(t.TempDir(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != "(prior artifact files not found)" {
+		t.Fatalf("got %q", s)
+	}
+}
+
+func TestFormatPriorPassArtifacts_roundFiles(t *testing.T) {
+	tmp := t.TempDir()
+	p1 := filepath.Join(tmp, "round-01-pass-1.json")
+	if err := os.WriteFile(p1, []byte(`{"k":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p2 := filepath.Join(tmp, "round-01-pass-2.json")
+	if err := os.WriteFile(p2, []byte(`{"round":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, err := formatPriorPassArtifacts(tmp, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(s, "round-01-pass-1") || !strings.Contains(s, `"k":1`) {
+		t.Fatalf("missing pass1: %q", s)
+	}
+	if !strings.Contains(s, "round-01-pass-2") || !strings.Contains(s, `"round":1`) {
+		t.Fatalf("missing pass2: %q", s)
+	}
+}
+
+func TestParsePass2Handoff_valid(t *testing.T) {
+	out := "preamble\n```" + pass2HandoffFenceTag + "\n" + `{"round":2,"gapSummary":"g","matrixDelta":"m","draftPRTitle":"t","draftPRBody":"b","gapNotes":"gn","conflictNotes":"cn"}` + "\n```\nCOMPLETE\n"
+	h, raw, perr := parsePass2Handoff(out)
+	if perr != "" {
+		t.Fatalf("parseErr: %s", perr)
+	}
+	if raw == "" || !strings.Contains(raw, "gapSummary") {
+		t.Fatalf("raw=%q", raw)
+	}
+	if h.Round != 2 || h.GapSummary != "g" || h.DraftPRTitle != "t" || h.ConflictNotes != "cn" {
+		t.Fatalf("%+v", h)
+	}
+}
+
+func TestParsePass2Handoff_noFence(t *testing.T) {
+	_, _, perr := parsePass2Handoff("no fence here")
+	if perr == "" {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(perr, "fenced") {
+		t.Fatalf("got %q", perr)
+	}
+}
+
+func TestParsePass2Handoff_invalidJSON(t *testing.T) {
+	out := "```" + pass2HandoffFenceTag + "\nnot-json\n```"
+	_, raw, perr := parsePass2Handoff(out)
+	if perr == "" {
+		t.Fatal("expected JSON error")
+	}
+	if raw != "not-json" {
+		t.Fatalf("raw=%q", raw)
+	}
+}
+
+func TestMergeSessionHandoff_trimsAndFlags(t *testing.T) {
+	last := PrePRPass2Handoff{
+		DraftPRTitle:  "  t  ",
+		DraftPRBody:   " b ",
+		GapNotes:      "\tx\n",
+		ConflictNotes: " y ",
+	}
+	got := mergeSessionHandoff(last, 3, true)
+	if got.DraftPRTitle != "t" || got.DraftPRBody != "b" || got.GapNotes != "x" || got.ConflictNotes != "y" {
+		t.Fatalf("%+v", got)
+	}
+	if got.FinalRound != 3 || !got.MatrixHadGaps {
+		t.Fatalf("%+v", got)
 	}
 }

--- a/internal/jrdev/pre_pr_review_test.go
+++ b/internal/jrdev/pre_pr_review_test.go
@@ -224,6 +224,34 @@ func TestParsePass5HandoffOptional_valid(t *testing.T) {
 	}
 }
 
+func TestParsePass5HandoffOptional_proseMentionWithoutFence(t *testing.T) {
+	out := "COMPLETE\nSee docs for " + pass5HandoffFenceTag + " format.\n"
+	h, raw, perr := parsePass5HandoffOptional(out)
+	if perr != "" || raw != "" || h != (PrePRPass5Handoff{}) {
+		t.Fatalf("optional handoff absent when only tag is mentioned in prose: h=%+v raw=%q perr=%q", h, raw, perr)
+	}
+}
+
+func TestParsePass5HandoffOptional_invalidJSONInFence(t *testing.T) {
+	body := "```" + pass5HandoffFenceTag + "\nnot-json\n```\n"
+	_, raw, perr := parsePass5HandoffOptional(body)
+	if perr == "" {
+		t.Fatal("expected JSON parse error")
+	}
+	if raw != "not-json" {
+		t.Fatalf("raw=%q", raw)
+	}
+}
+
+func TestParsePass5HandoffOptional_twoFencesErrors(t *testing.T) {
+	tag := pass5HandoffFenceTag
+	body := "```" + tag + "\n{}\n```\n```" + tag + "\n{}\n```\n"
+	_, _, perr := parsePass5HandoffOptional(body)
+	if perr == "" || !strings.Contains(perr, "exactly one") {
+		t.Fatalf("got %q", perr)
+	}
+}
+
 func TestMergePass5HandoffIntoSessionFile(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "handoff.json")

--- a/internal/jrdev/pre_pr_review_test.go
+++ b/internal/jrdev/pre_pr_review_test.go
@@ -99,6 +99,39 @@ func TestParsePass2Handoff_invalidJSON(t *testing.T) {
 	}
 }
 
+func TestParsePass3Artifact_valid(t *testing.T) {
+	raw := `{"summary":"s","testDesign":"td","coverage":"c","prdTestingAlignment":"p","strictnessInference":"i","followUps":"f"}`
+	out := "intro\n```" + pass3ArtifactFenceTag + "\n" + raw + "\n```\nCOMPLETE\n"
+	a, inner, perr := parsePass3Artifact(out)
+	if perr != "" {
+		t.Fatalf("parseErr: %s", perr)
+	}
+	if inner != raw {
+		t.Fatalf("inner=%q", inner)
+	}
+	if a.Summary != "s" || a.TestDesign != "td" || a.FollowUps != "f" {
+		t.Fatalf("%+v", a)
+	}
+}
+
+func TestParsePass3Artifact_noFence(t *testing.T) {
+	_, _, perr := parsePass3Artifact("no fence")
+	if perr == "" {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParsePass3Artifact_invalidJSON(t *testing.T) {
+	out := "```" + pass3ArtifactFenceTag + "\nnot-json\n```"
+	_, raw, perr := parsePass3Artifact(out)
+	if perr == "" {
+		t.Fatal("expected JSON error")
+	}
+	if raw != "not-json" {
+		t.Fatalf("raw=%q", raw)
+	}
+}
+
 func TestMergeSessionHandoff_trimsAndFlags(t *testing.T) {
 	last := PrePRPass2Handoff{
 		DraftPRTitle:  "  t  ",

--- a/internal/jrdev/pre_pr_review_test.go
+++ b/internal/jrdev/pre_pr_review_test.go
@@ -1,6 +1,7 @@
 package jrdev
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -129,6 +130,79 @@ func TestParsePass3Artifact_invalidJSON(t *testing.T) {
 	}
 	if raw != "not-json" {
 		t.Fatalf("raw=%q", raw)
+	}
+}
+
+func TestParsePass3Artifact_twoFences(t *testing.T) {
+	two := "```" + pass3ArtifactFenceTag + "\n{}\n```\n```" + pass3ArtifactFenceTag + "\n{}\n```"
+	_, _, perr := parsePass3Artifact(two)
+	if perr == "" || !strings.Contains(perr, "exactly one") {
+		t.Fatalf("got %q", perr)
+	}
+}
+
+func TestParsePass3Artifact_unclosedFence(t *testing.T) {
+	_, _, perr := parsePass3Artifact("```" + pass3ArtifactFenceTag + "\n{\"x\":1}\n")
+	if perr == "" || !strings.Contains(perr, "unclosed") {
+		t.Fatalf("expected unclosed fence error, got %q", perr)
+	}
+}
+
+func TestWritePass3Artifact_success(t *testing.T) {
+	tmp := t.TempDir()
+	art := PrePRPass3Artifact{
+		Summary:             "s",
+		TestDesign:          "td",
+		Coverage:            "c",
+		PRDTestingAlignment: "p",
+		StrictnessInference: "i",
+		FollowUps:           "f",
+	}
+	raw := `{"summary":"s","testDesign":"td"}`
+	if err := writePass3Artifact(tmp, 2, art, raw, ""); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(tmp, "pass-3.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var w struct {
+		FinalRound  int                `json:"finalRound"`
+		Artifact    PrePRPass3Artifact `json:"artifact"`
+		ArtifactRaw string             `json:"artifactFenceInner,omitempty"`
+		ParseErr    string             `json:"artifactParseError,omitempty"`
+	}
+	if err := json.Unmarshal(b, &w); err != nil {
+		t.Fatal(err)
+	}
+	if w.FinalRound != 2 || w.ArtifactRaw != "" || w.ParseErr != "" {
+		t.Fatalf("%+v", w)
+	}
+	if w.Artifact.Summary != "s" || w.Artifact.TestDesign != "td" {
+		t.Fatalf("%+v", w.Artifact)
+	}
+}
+
+func TestWritePass3Artifact_parseErrorPreservesRaw(t *testing.T) {
+	tmp := t.TempDir()
+	if err := writePass3Artifact(tmp, 1, PrePRPass3Artifact{}, "not-json", "invalid character"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(tmp, "pass-3.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var w struct {
+		FinalRound int `json:"finalRound"`
+		Artifact   PrePRPass3Artifact
+		Raw        string `json:"artifactFenceInner,omitempty"`
+		ParseErr   string `json:"artifactParseError,omitempty"`
+	}
+	if err := json.Unmarshal(b, &w); err != nil {
+		t.Fatal(err)
+	}
+	if w.FinalRound != 1 || w.Raw != "not-json" || !strings.Contains(w.ParseErr, "invalid") {
+		t.Fatalf("finalRound=%d raw=%q err=%q", w.FinalRound, w.Raw, w.ParseErr)
 	}
 }
 

--- a/internal/jrdev/pre_pr_review_test.go
+++ b/internal/jrdev/pre_pr_review_test.go
@@ -1,0 +1,18 @@
+package jrdev
+
+import "testing"
+
+func TestNewPrePRRunID_length(t *testing.T) {
+	id, err := newPrePRRunID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(id) != 8 {
+		t.Fatalf("runId %q len=%d", id, len(id))
+	}
+	for _, r := range id {
+		if r < '0' || r > 'f' || (r > '9' && r < 'a') {
+			t.Fatalf("non-hex in %q", id)
+		}
+	}
+}

--- a/internal/jrdev/render.go
+++ b/internal/jrdev/render.go
@@ -101,6 +101,20 @@ type PrePRReviewPass3PromptData struct {
 	FinalRound                 int
 }
 
+// PrePRReviewPass5PromptData is passed to prompt_pre_pr_review_pass5.md (GM-010 — logs only from jrdev).
+type PrePRReviewPass5PromptData struct {
+	IntegrationBranch   string
+	IntegrationBase     string
+	IssueNumbers        []int
+	FailingKind         string // lint | unit | integration
+	FailingCommand      string
+	CapturedLogs        string
+	NonInteractive      bool
+	BonusSteeringNote   string
+	Pass5Round          int
+	Fingerprint         string
+}
+
 // Render treats body as a Go text/template with the given name for errors.
 func Render(name, body string, data any) (string, error) {
 	tmpl, err := template.New(name).Parse(body)

--- a/internal/jrdev/render.go
+++ b/internal/jrdev/render.go
@@ -87,6 +87,20 @@ type PrePRReviewPass2PromptData struct {
 	CurrentPass1MatrixJSON     string // indented JSON from validated matrix this round
 }
 
+// PrePRReviewPass3PromptData is passed to prompt_pre_pr_review_pass3.md (GM-008 — no lint/unit in prompt).
+type PrePRReviewPass3PromptData struct {
+	IntegrationBranch          string
+	IntegrationBase            string
+	IssueNumbers               []int
+	IssuesMarkdown             string
+	CommitHistory              string
+	GitDiff                    string
+	NonInteractive             bool
+	PriorPassArtifactsMarkdown string
+	SessionHandoffJSON         string // raw JSON from handoff.json (pretty optional; passed as string)
+	FinalRound                 int
+}
+
 // Render treats body as a Go text/template with the given name for errors.
 func Render(name, body string, data any) (string, error) {
 	tmpl, err := template.New(name).Parse(body)

--- a/internal/jrdev/render.go
+++ b/internal/jrdev/render.go
@@ -54,6 +54,19 @@ type PRPromptData struct {
 	GitDiff           string
 }
 
+// PrePRReviewPass1PromptData is passed to prompt_pre_pr_review_pass1.md.
+type PrePRReviewPass1PromptData struct {
+	IntegrationBranch string
+	IntegrationBase   string
+	IssueNumbers      []int
+	IssuesMarkdown    string // gh-fetched bodies + headings
+	CommitHistory     string
+	GitDiff           string
+	LintTests         string
+	UnitTests         string
+	NonInteractive    bool
+}
+
 // Render treats body as a Go text/template with the given name for errors.
 func Render(name, body string, data any) (string, error) {
 	tmpl, err := template.New(name).Parse(body)

--- a/internal/jrdev/render.go
+++ b/internal/jrdev/render.go
@@ -65,6 +65,26 @@ type PrePRReviewPass1PromptData struct {
 	LintTests         string
 	UnitTests         string
 	NonInteractive    bool
+	PriorPassArtifactsMarkdown string // full serialized prior pass outputs (GM-007)
+	BonusSteeringNote          string // 4th cycle; interactive note or non-interactive best-judgment line
+	Round                      int    // 1-based pass number for this Pass 1 invocation
+}
+
+// PrePRReviewPass2PromptData is passed to prompt_pre_pr_review_pass2.md.
+type PrePRReviewPass2PromptData struct {
+	IntegrationBranch string
+	IntegrationBase   string
+	IssueNumbers      []int
+	IssuesMarkdown    string
+	CommitHistory     string
+	GitDiff           string
+	LintTests         string
+	UnitTests         string
+	NonInteractive    bool
+	PriorPassArtifactsMarkdown string
+	BonusSteeringNote          string
+	Round                      int
+	CurrentPass1MatrixJSON     string // indented JSON from validated matrix this round
 }
 
 // Render treats body as a Go text/template with the given name for errors.

--- a/internal/jrdev/render.go
+++ b/internal/jrdev/render.go
@@ -52,6 +52,10 @@ type PRPromptData struct {
 	PRBase            string // compare branch for the PR (e.g. main)
 	CommitHistory     string
 	GitDiff           string
+	// PrePRReview* optional context from .jrdev/pre-pr-review/latest (GM-012).
+	PrePRReviewHandoffPresent bool
+	PrePRReviewHandoffSummary string
+	PrePRReviewArtifactPaths  string // markdown list; empty when Present is false
 }
 
 // PrePRReviewPass1PromptData is passed to prompt_pre_pr_review_pass1.md.

--- a/internal/jrdev/run.go
+++ b/internal/jrdev/run.go
@@ -216,7 +216,7 @@ func Run(cfg Config, prompts PromptBundle, agent AgentRunner, log func(string, .
 			}
 			return Render("implement", prompts.Implement, implData)
 		}
-		implOut, err := runAgentUntilComplete(cfg, agent, log, "implement", issuePath, renderImplement)
+		implOut, err := runAgentUntilComplete(cfg, agent, log, "implement", issuePath, renderImplement, true)
 		if err != nil {
 			return err
 		}
@@ -232,7 +232,7 @@ func Run(cfg Config, prompts PromptBundle, agent AgentRunner, log func(string, .
 		}
 		if commits == 0 && !noCommitOK {
 			log("jrdev: zero commits after implement — retrying implement phase.\n")
-			implOut, err = runAgentUntilComplete(cfg, agent, log, "implement", issuePath, renderImplement)
+			implOut, err = runAgentUntilComplete(cfg, agent, log, "implement", issuePath, renderImplement, true)
 			if err != nil {
 				return err
 			}
@@ -264,7 +264,7 @@ func Run(cfg Config, prompts PromptBundle, agent AgentRunner, log func(string, .
 				}
 				return Render("review", prompts.Review, implData)
 			}
-			if _, err := runAgentUntilComplete(cfg, agent, log, "review", issuePath, renderReview); err != nil {
+			if _, err := runAgentUntilComplete(cfg, agent, log, "review", issuePath, renderReview, true); err != nil {
 				return err
 			}
 		}
@@ -291,7 +291,7 @@ func Run(cfg Config, prompts PromptBundle, agent AgentRunner, log func(string, .
 			}
 			return Render("merge", prompts.Merge, mergeData)
 		}
-		mergeOut, err := runAgentUntilComplete(cfg, agent, log, "merge", intPath, renderMerge)
+		mergeOut, err := runAgentUntilComplete(cfg, agent, log, "merge", intPath, renderMerge, true)
 		if err != nil {
 			return fmt.Errorf("merge phase: %w", err)
 		}
@@ -377,7 +377,8 @@ func Run(cfg Config, prompts PromptBundle, agent AgentRunner, log func(string, .
 
 // runAgentUntilComplete invokes agent.Run with a fresh prompt from render on each attempt until stdout
 // contains AgentPhaseCompleteToken or maxAgentStepAttempts is reached.
-func runAgentUntilComplete(cfg Config, agent AgentRunner, log func(string, ...any), phase, workDir string, render func() (string, error)) (string, error) {
+// agentPrint is passed to AgentRunOptions.Print (TTY workflows use false for Pass 1 per GM-011).
+func runAgentUntilComplete(cfg Config, agent AgentRunner, log func(string, ...any), phase, workDir string, render func() (string, error), agentPrint bool) (string, error) {
 	var lastOut string
 	for attempt := 1; attempt <= maxAgentStepAttempts; attempt++ {
 		body, err := render()
@@ -385,7 +386,7 @@ func runAgentUntilComplete(cfg Config, agent AgentRunner, log func(string, ...an
 			return "", err
 		}
 		vlog(cfg, log, "jrdev: verbose: %s — attempt %d/%d, prompt %d bytes\n", phase, attempt, maxAgentStepAttempts, len(body))
-		out, err := agent.Run(cfg, workDir, body, AgentRunOptions{Print: true})
+		out, err := agent.Run(cfg, workDir, body, AgentRunOptions{Print: agentPrint})
 		lastOut = out
 		if err != nil {
 			return out, fmt.Errorf("%s: %w", phase, err)

--- a/internal/jrdev/run_test.go
+++ b/internal/jrdev/run_test.go
@@ -26,7 +26,7 @@ func TestRunAgentUntilComplete(t *testing.T) {
 	_, err := runAgentUntilComplete(cfg, a, nil, "test", "/tmp", func() (string, error) {
 		renders++
 		return "prompt", nil
-	})
+	}, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestRunAgentUntilComplete_exhausted(t *testing.T) {
 	cfg := Config{}
 	_, err := runAgentUntilComplete(cfg, a, nil, "test", "/tmp", func() (string, error) {
 		return "p", nil
-	})
+	}, true)
 	if err == nil || !strings.Contains(err.Error(), "never contained") {
 		t.Fatalf("expected exhaustion error, got %v", err)
 	}

--- a/internal/jrdev/types.go
+++ b/internal/jrdev/types.go
@@ -10,6 +10,9 @@ const AgentImplementNoCommitToken = "COMPLETE NO COMMIT"
 // CompletionMarker is a merge-phase convention; any output containing AgentPhaseCompleteToken satisfies validation.
 const CompletionMarker = "<promise>COMPLETE</promise>"
 
+// PrePRReviewBonusCycleSteeringNonInteractive is appended to the bonus Pass 1→2 cycle when stdin is not a TTY (GM-007).
+const PrePRReviewBonusCycleSteeringNonInteractive = "Continue with best judgment: do not ask for user input. Address the remaining matrix gaps and conflicts with minimal, test-backed fixes; use the required commit message prefix for every commit; prefer correctness over scope creep."
+
 // PlannedIssue is one row from planner JSON inside <plan>.
 type PlannedIssue struct {
 	Number int    `json:"number"`

--- a/internal/jrdev/types.go
+++ b/internal/jrdev/types.go
@@ -13,6 +13,9 @@ const CompletionMarker = "<promise>COMPLETE</promise>"
 // PrePRReviewBonusCycleSteeringNonInteractive is appended to the bonus Pass 1→2 cycle when stdin is not a TTY (GM-007).
 const PrePRReviewBonusCycleSteeringNonInteractive = "Continue with best judgment: do not ask for user input. Address the remaining matrix gaps and conflicts with minimal, test-backed fixes; use the required commit message prefix for every commit; prefer correctness over scope creep."
 
+// PrePRReviewPass5BonusCycleSteeringNonInteractive is used for the fourth Pass 5 round when stdin is not a TTY (GM-010, GM-011).
+const PrePRReviewPass5BonusCycleSteeringNonInteractive = "Continue with best judgment: do not ask for user input. Fix the remaining check failure with minimal PRD-aligned changes; respect GM-010 (no weakening tests to go green). Use the required commit message prefix for every commit."
+
 // PlannedIssue is one row from planner JSON inside <plan>.
 type PlannedIssue struct {
 	Number int    `json:"number"`

--- a/main.go
+++ b/main.go
@@ -327,7 +327,7 @@ func usage(name string, w io.Writer) {
 	fmt.Fprintf(&b, "Syntax:\n")
 	fmt.Fprintf(&b, "  %s [flags]\n", name)
 	fmt.Fprintf(&b, "  %s init [flags]   interactive setup wizard for .jrdev/config.yaml\n", name)
-		fmt.Fprintf(&b, "  %s pre-pr-review [flags]   issue discovery + Pass 1↔2 loop + Pass 3 test-design review on integration branch checkout\n", name)
+	fmt.Fprintf(&b, "  %s pre-pr-review [flags]   issue discovery + Pass 1↔2 loop + Pass 3 test-design review on integration branch checkout\n", name)
 	fmt.Fprintf(&b, "  %s help\n", name)
 	fmt.Fprintf(&b, "  %s -h | -help | --help\n\n", name)
 	fmt.Fprintf(&b, "Typical calls:\n")

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/NUSAlaska/jrdev/internal/jrdev"
 )
 
-//go:embed prompt_plan.md prompt_implement.md prompt_review.md prompt_merge.md prompt_pr.md prompt_pre_pr_review_pass1.md prompt_pre_pr_review_pass2.md
+//go:embed prompt_plan.md prompt_implement.md prompt_review.md prompt_merge.md prompt_pr.md prompt_pre_pr_review_pass1.md prompt_pre_pr_review_pass2.md prompt_pre_pr_review_pass3.md
 var promptFS embed.FS
 
 func main() {
@@ -310,7 +310,11 @@ func loadPrompts() (jrdev.PromptBundle, error) {
 	if err != nil {
 		return jrdev.PromptBundle{}, err
 	}
-	return jrdev.PromptBundle{Plan: plan, Implement: impl, Review: rev, Merge: mer, PR: pr, PrePRReviewPass1: p1, PrePRReviewPass2: p2}, nil
+	p3, err := read("prompt_pre_pr_review_pass3.md")
+	if err != nil {
+		return jrdev.PromptBundle{}, err
+	}
+	return jrdev.PromptBundle{Plan: plan, Implement: impl, Review: rev, Merge: mer, PR: pr, PrePRReviewPass1: p1, PrePRReviewPass2: p2, PrePRReviewPass3: p3}, nil
 }
 
 func programName() string {
@@ -323,7 +327,7 @@ func usage(name string, w io.Writer) {
 	fmt.Fprintf(&b, "Syntax:\n")
 	fmt.Fprintf(&b, "  %s [flags]\n", name)
 	fmt.Fprintf(&b, "  %s init [flags]   interactive setup wizard for .jrdev/config.yaml\n", name)
-	fmt.Fprintf(&b, "  %s pre-pr-review [flags]   issue discovery + Pass 1↔2 pre-PR review loop on integration branch checkout\n", name)
+		fmt.Fprintf(&b, "  %s pre-pr-review [flags]   issue discovery + Pass 1↔2 loop + Pass 3 test-design review on integration branch checkout\n", name)
 	fmt.Fprintf(&b, "  %s help\n", name)
 	fmt.Fprintf(&b, "  %s -h | -help | --help\n\n", name)
 	fmt.Fprintf(&b, "Typical calls:\n")

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/NUSAlaska/jrdev/internal/jrdev"
 )
 
-//go:embed prompt_plan.md prompt_implement.md prompt_review.md prompt_merge.md prompt_pr.md
+//go:embed prompt_plan.md prompt_implement.md prompt_review.md prompt_merge.md prompt_pr.md prompt_pre_pr_review_pass1.md
 var promptFS embed.FS
 
 func main() {
@@ -27,9 +27,18 @@ func run() int {
 	name := programName()
 	args := os.Args[1:]
 	sub := "run"
-	if len(args) > 0 && args[0] == "init" {
-		sub = "init"
-		args = args[1:]
+	if len(args) > 0 {
+		switch args[0] {
+		case "init":
+			sub = "init"
+			args = args[1:]
+		case "pre-pr-review":
+			sub = "pre-pr-review"
+			args = args[1:]
+		case "help", "-help", "--help":
+			usage(name, os.Stdout)
+			return 0
+		}
 	}
 	if len(args) > 0 && (args[0] == "help" || args[0] == "-help" || args[0] == "--help") {
 		usage(name, os.Stdout)
@@ -250,6 +259,14 @@ func run() int {
 		a = jrdev.OSAgentRunner{Log: log}
 	}
 
+	if sub == "pre-pr-review" {
+		if err := jrdev.RunPrePrReview(cfg, prompts, a, startDir, log); err != nil {
+			fmt.Fprintf(os.Stderr, "jrdev: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+
 	if err := jrdev.Run(cfg, prompts, a, log); err != nil {
 		fmt.Fprintf(os.Stderr, "jrdev: %v\n", err)
 		return 1
@@ -285,7 +302,11 @@ func loadPrompts() (jrdev.PromptBundle, error) {
 	if err != nil {
 		return jrdev.PromptBundle{}, err
 	}
-	return jrdev.PromptBundle{Plan: plan, Implement: impl, Review: rev, Merge: mer, PR: pr}, nil
+	p1, err := read("prompt_pre_pr_review_pass1.md")
+	if err != nil {
+		return jrdev.PromptBundle{}, err
+	}
+	return jrdev.PromptBundle{Plan: plan, Implement: impl, Review: rev, Merge: mer, PR: pr, PrePRReviewPass1: p1}, nil
 }
 
 func programName() string {
@@ -298,6 +319,7 @@ func usage(name string, w io.Writer) {
 	fmt.Fprintf(&b, "Syntax:\n")
 	fmt.Fprintf(&b, "  %s [flags]\n", name)
 	fmt.Fprintf(&b, "  %s init [flags]   interactive setup wizard for .jrdev/config.yaml\n", name)
+	fmt.Fprintf(&b, "  %s pre-pr-review [flags]   issue discovery + Pass 1 PRD matrix on integration branch checkout\n", name)
 	fmt.Fprintf(&b, "  %s help\n", name)
 	fmt.Fprintf(&b, "  %s -h | -help | --help\n\n", name)
 	fmt.Fprintf(&b, "Typical calls:\n")

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/NUSAlaska/jrdev/internal/jrdev"
 )
 
-//go:embed prompt_plan.md prompt_implement.md prompt_review.md prompt_merge.md prompt_pr.md prompt_pre_pr_review_pass1.md
+//go:embed prompt_plan.md prompt_implement.md prompt_review.md prompt_merge.md prompt_pr.md prompt_pre_pr_review_pass1.md prompt_pre_pr_review_pass2.md
 var promptFS embed.FS
 
 func main() {
@@ -306,7 +306,11 @@ func loadPrompts() (jrdev.PromptBundle, error) {
 	if err != nil {
 		return jrdev.PromptBundle{}, err
 	}
-	return jrdev.PromptBundle{Plan: plan, Implement: impl, Review: rev, Merge: mer, PR: pr, PrePRReviewPass1: p1}, nil
+	p2, err := read("prompt_pre_pr_review_pass2.md")
+	if err != nil {
+		return jrdev.PromptBundle{}, err
+	}
+	return jrdev.PromptBundle{Plan: plan, Implement: impl, Review: rev, Merge: mer, PR: pr, PrePRReviewPass1: p1, PrePRReviewPass2: p2}, nil
 }
 
 func programName() string {
@@ -319,7 +323,7 @@ func usage(name string, w io.Writer) {
 	fmt.Fprintf(&b, "Syntax:\n")
 	fmt.Fprintf(&b, "  %s [flags]\n", name)
 	fmt.Fprintf(&b, "  %s init [flags]   interactive setup wizard for .jrdev/config.yaml\n", name)
-	fmt.Fprintf(&b, "  %s pre-pr-review [flags]   issue discovery + Pass 1 PRD matrix on integration branch checkout\n", name)
+		fmt.Fprintf(&b, "  %s pre-pr-review [flags]   issue discovery + Pass 1↔2 pre-PR review loop on integration branch checkout\n", name)
 	fmt.Fprintf(&b, "  %s help\n", name)
 	fmt.Fprintf(&b, "  %s -h | -help | --help\n\n", name)
 	fmt.Fprintf(&b, "Typical calls:\n")

--- a/main.go
+++ b/main.go
@@ -323,7 +323,7 @@ func usage(name string, w io.Writer) {
 	fmt.Fprintf(&b, "Syntax:\n")
 	fmt.Fprintf(&b, "  %s [flags]\n", name)
 	fmt.Fprintf(&b, "  %s init [flags]   interactive setup wizard for .jrdev/config.yaml\n", name)
-		fmt.Fprintf(&b, "  %s pre-pr-review [flags]   issue discovery + Pass 1↔2 pre-PR review loop on integration branch checkout\n", name)
+	fmt.Fprintf(&b, "  %s pre-pr-review [flags]   issue discovery + Pass 1↔2 pre-PR review loop on integration branch checkout\n", name)
 	fmt.Fprintf(&b, "  %s help\n", name)
 	fmt.Fprintf(&b, "  %s -h | -help | --help\n\n", name)
 	fmt.Fprintf(&b, "Typical calls:\n")

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/NUSAlaska/jrdev/internal/jrdev"
 )
 
-//go:embed prompt_plan.md prompt_implement.md prompt_review.md prompt_merge.md prompt_pr.md prompt_pre_pr_review_pass1.md prompt_pre_pr_review_pass2.md prompt_pre_pr_review_pass3.md
+//go:embed prompt_plan.md prompt_implement.md prompt_review.md prompt_merge.md prompt_pr.md prompt_pre_pr_review_pass1.md prompt_pre_pr_review_pass2.md prompt_pre_pr_review_pass3.md prompt_pre_pr_review_pass5.md
 var promptFS embed.FS
 
 func main() {
@@ -314,7 +314,11 @@ func loadPrompts() (jrdev.PromptBundle, error) {
 	if err != nil {
 		return jrdev.PromptBundle{}, err
 	}
-	return jrdev.PromptBundle{Plan: plan, Implement: impl, Review: rev, Merge: mer, PR: pr, PrePRReviewPass1: p1, PrePRReviewPass2: p2, PrePRReviewPass3: p3}, nil
+	p5, err := read("prompt_pre_pr_review_pass5.md")
+	if err != nil {
+		return jrdev.PromptBundle{}, err
+	}
+	return jrdev.PromptBundle{Plan: plan, Implement: impl, Review: rev, Merge: mer, PR: pr, PrePRReviewPass1: p1, PrePRReviewPass2: p2, PrePRReviewPass3: p3, PrePRReviewPass5: p5}, nil
 }
 
 func programName() string {
@@ -327,7 +331,7 @@ func usage(name string, w io.Writer) {
 	fmt.Fprintf(&b, "Syntax:\n")
 	fmt.Fprintf(&b, "  %s [flags]\n", name)
 	fmt.Fprintf(&b, "  %s init [flags]   interactive setup wizard for .jrdev/config.yaml\n", name)
-	fmt.Fprintf(&b, "  %s pre-pr-review [flags]   issue discovery + Pass 1↔2 loop + Pass 3 test-design review on integration branch checkout\n", name)
+	fmt.Fprintf(&b, "  %s pre-pr-review [flags]   issue discovery + Pass 1↔2 + Pass 3 + Pass 4 checks + Pass 5 fix loop on integration branch checkout\n", name)
 	fmt.Fprintf(&b, "  %s help\n", name)
 	fmt.Fprintf(&b, "  %s -h | -help | --help\n\n", name)
 	fmt.Fprintf(&b, "Typical calls:\n")

--- a/prompt_pr.md
+++ b/prompt_pr.md
@@ -8,6 +8,20 @@ You help write a **GitHub pull request** for an automated integration branch pro
 - **Queue label:** `{{.QueueLabel}}`
 - **PR base:** `{{.PRBase}}` (compare commits and diff against this branch)
 
+{{if .PrePRReviewHandoffPresent}}
+## Pre-pr-review handoff (latest run)
+
+The branch has **pre-pr-review** artifacts recorded under **`.jrdev/pre-pr-review/`**. Treat the handoff below as authoritative for **what the review passes concluded** (matrix gaps, testing notes, check status) and for **draft PR text** from earlier passes when present. **Still reconcile** with the commit list and diff below; if they disagree, prefer facts visible in git and call out the mismatch in the PR body.
+
+### Summaries
+
+{{.PrePRReviewHandoffSummary}}
+
+### Artifact paths (JSON)
+
+{{.PrePRReviewArtifactPaths}}
+{{end}}
+
 ## Recent commits on the integration branch
 
 ```
@@ -27,7 +41,8 @@ You help write a **GitHub pull request** for an automated integration branch pro
    - Explains **what** changed and **why** (for reviewers),
    - Calls out **risk areas** or **follow-ups** if obvious from the diff,
    - Uses a short bullet list when it helps readability.
-3. Base your summary only on the commit messages and diff above; do not invent files or behavior not shown there.
+3. When the **pre-pr-review handoff** section is present above, **use it**: surface draft title/body and gap/testing/check-status notes where they help reviewers; merge them with the git story instead of ignoring them.
+4. Ground claims in **git** (commits + diff). Do not invent files or behavior not supported by the diff/commits and handoff text; if the handoff references detail that is not in the diff, phrase it cautiously or point readers to the listed artifact JSON files.
 
 ## Required output format (exact tags)
 

--- a/prompt_pre_pr_review_pass1.md
+++ b/prompt_pre_pr_review_pass1.md
@@ -22,6 +22,18 @@ If a body links to other issues (for example a parent PRD) by URL or `#n`, read 
 Standard input is **not** a TTY. **Do not** wait for user input or ask the operator questions. Use best judgment; proceed deterministically.
 {{end}}
 
+{{if .BonusSteeringNote}}
+## Operator steering (bonus Pass 1→2 cycle)
+
+{{.BonusSteeringNote}}
+
+{{end}}
+{{if .PriorPassArtifactsMarkdown}}
+## Prior pass artifacts (full history so far)
+
+{{.PriorPassArtifactsMarkdown}}
+
+{{end}}
 ## Repository context
 
 Last commits in this worktree:

--- a/prompt_pre_pr_review_pass1.md
+++ b/prompt_pre_pr_review_pass1.md
@@ -1,0 +1,73 @@
+# jrdev — Pre-PR review — Pass 1 (requirements matrix)
+
+You are in the **integration git worktree** on branch **`{{.IntegrationBranch}}`**. This is **Pass 1 only**: build a structured requirements matrix from the linked issues; do **not** run later passes.
+
+## Linked issues (scope)
+
+These issue numbers were discovered from `git log {{.IntegrationBase}}..HEAD` (Fixes/Closes/Resolves #n) and, when applicable, from GitHub **closing references** on the PR for this branch:
+
+{{range $i, $n := .IssueNumbers}}{{if $i}}, {{end}}#{{$n}}{{end}}
+
+### Issue bodies (primary requirements substrate)
+
+{{.IssuesMarkdown}}
+
+### Linked issues and PRDs (private GitHub)
+
+If a body links to other issues (for example a parent PRD) by URL or `#n`, read them with **`gh issue view`** from the repository root — not unauthenticated HTTP or **WebFetch**.
+
+{{if .NonInteractive}}
+## Non-interactive mode
+
+Standard input is **not** a TTY. **Do not** wait for user input or ask the operator questions. Use best judgment; proceed deterministically.
+{{end}}
+
+## Repository context
+
+Last commits in this worktree:
+
+```
+{{.CommitHistory}}
+```
+
+Diff (**main**..HEAD):
+
+```
+{{.GitDiff}}
+```
+
+**Integration base** (same as jrdev `--integration-base`): `{{.IntegrationBase}}`
+
+## Configured checks (repository `.jrdev/config.yaml`)
+
+**Lint** (for awareness; you do not need to green the branch in Pass 1):
+
+{{.LintTests}}
+
+**Unit** (for awareness):
+
+{{.UnitTests}}
+
+## Task (GM-005 / grill-me matrix)
+
+1. Treat each issue body as the **primary requirements substrate**: infer **atomic requirements** from headings, bullets, user stories, tables, checklists, or prose — even when wording is informal.
+2. For **each** atomic requirement row:
+   - **`id`**: stable identifier (e.g. `REQ-001`).
+   - **`verbatimQuote`**: a **short verbatim quote** from the issue (or parent PRD if you followed a link) for traceability.
+   - **`status`**: one of `satisfied`, `not_satisfied`, `unknown`, `conflict` — judged against **this integration branch** (code + tests in the repo).
+   - **`evidence.paths`**: relevant file paths (repo-relative); use `[]` only when no paths apply.
+   - **`evidence.tests`**: concrete test proof: repo path + test name or `go test -run=…` (or equivalent). For **`satisfied`**, every row must list **at least one non-empty** test string unless tests are genuinely not the right proof — in that case **do not** claim `satisfied`.
+   - **`notes`**: short rationale, gaps, or follow-ups.
+3. Emit **exactly one** markdown fenced block whose info string is **`jrdev-prd-matrix`** containing a **single JSON object** with:
+   - **`schemaVersion`** (non-empty string, e.g. `"1"`),
+   - **`requirements`**: array of row objects as above.
+
+Example fence (structure only):
+
+```jrdev-prd-matrix
+{ "schemaVersion": "1", "requirements": [] }
+```
+
+## Completion
+
+When the matrix is emitted and correct, end your output with the word **`COMPLETE`** **on its own line** so jrdev can detect completion (avoid burying `COMPLETE` inside other text).

--- a/prompt_pre_pr_review_pass1.md
+++ b/prompt_pre_pr_review_pass1.md
@@ -30,7 +30,7 @@ Last commits in this worktree:
 {{.CommitHistory}}
 ```
 
-Diff (**main**..HEAD):
+Diff ({{.IntegrationBase}}..HEAD):
 
 ```
 {{.GitDiff}}

--- a/prompt_pre_pr_review_pass2.md
+++ b/prompt_pre_pr_review_pass2.md
@@ -1,0 +1,103 @@
+# jrdev — Pre-PR review — Pass 2 (gap fixes)
+
+You are in the **integration git worktree** on branch **`{{.IntegrationBranch}}`**. This is **Pass 2 only**: fix gaps called out by the **current** Pass 1 matrix for **round {{.Round}}**. Do **not** re-run a full Pass 1 resweep yourself; jrdev will run Pass 1 again on the next cycle if needed.
+
+## Linked issues (scope)
+
+{{range $i, $n := .IssueNumbers}}{{if $i}}, {{end}}#{{$n}}{{end}}
+
+### Issue bodies (context)
+
+{{.IssuesMarkdown}}
+
+### Linked issues and PRDs (private GitHub)
+
+If a body links to other issues (for example a parent PRD) by URL or `#n`, read them with **`gh issue view`** from the repository root — not unauthenticated HTTP or **WebFetch**.
+
+{{if .NonInteractive}}
+## Non-interactive mode
+
+Standard input is **not** a TTY. **Do not** wait for user input or ask the operator questions. Use best judgment; proceed deterministically (same spirit as other jrdev non-interactive agent phases).
+{{end}}
+
+{{if .BonusSteeringNote}}
+## Operator steering (bonus Pass 1→2 cycle)
+
+{{.BonusSteeringNote}}
+
+{{end}}
+{{if .PriorPassArtifactsMarkdown}}
+## Prior pass artifacts (full history so far)
+
+{{.PriorPassArtifactsMarkdown}}
+
+{{end}}
+
+## Current Pass 1 matrix (this round)
+
+Valid JSON requirements matrix from Pass 1 (address every row with status `not_satisfied`, `unknown`, or `conflict`; improve evidence where weak):
+
+```json
+{{.CurrentPass1MatrixJSON}}
+```
+
+## Repository context
+
+Last commits in this worktree:
+
+```
+{{.CommitHistory}}
+```
+
+Diff ({{.IntegrationBase}}..HEAD):
+
+```
+{{.GitDiff}}
+```
+
+**Integration base**: `{{.IntegrationBase}}`
+
+## Configured checks
+
+**Lint** (run when you change code; fix new violations you introduce):
+
+{{.LintTests}}
+
+**Unit** (run when you change code):
+
+{{.UnitTests}}
+
+## Task (GM-007 — gap fixes)
+
+1. Prioritize rows with `not_satisfied`, then `conflict`, then `unknown`.
+2. Make **minimal** code or test changes that move requirements toward **satisfied** with real evidence. **Do not** broaden scope beyond the linked issues / matrix.
+3. **Every commit** on this pass must use a subject line starting with **`JRDEV: Pre-PR review pass 2 -`** (prefix exactly; you may add a short description after the dash).
+4. When you touch code, run the repo’s configured **lint** and **unit** commands above and keep them green for your edits.
+5. Leave the working tree **clean** when you finish (all changes committed — jrdev will verify before the next cycle).
+6. **Do not** automatically produce a new full requirements matrix (no Pass 1 resweep); focus on fixes.
+7. Emit **exactly one** markdown fenced block tagged **`jrdev-pre-pr-review-handoff`** containing a single JSON object with:
+   - **`round`**: integer, must match **{{.Round}}**
+   - **`gapSummary`**: short description of what you fixed or punted
+   - **`matrixDelta`**: free text describing how the branch state moved relative to the matrix (tests, files, decisions)
+   - **`draftPRTitle`**: suggested PR title for the integration branch (for the human PR author step / GM-012)
+   - **`draftPRBody`**: suggested PR body (markdown plain text inside the JSON string)
+   - **`gapNotes`**: remaining gaps or follow-ups for the author
+   - **`conflictNotes`**: notable conflicts or ambiguities still open
+
+Example structure (fill with real values):
+
+```jrdev-pre-pr-review-handoff
+{
+  "round": {{.Round}},
+  "gapSummary": "",
+  "matrixDelta": "",
+  "draftPRTitle": "",
+  "draftPRBody": "",
+  "gapNotes": "",
+  "conflictNotes": ""
+}
+```
+
+## Completion
+
+When fixes and the handoff fence are emitted, end with **`COMPLETE`** on its own line. If **no** commits or working-tree edits are needed, you may use **`COMPLETE NO COMMIT`** on its own line instead (then still emit the handoff fence with honest `gapSummary` / notes). If you use **`COMPLETE NO COMMIT`**, the working tree must still be clean.

--- a/prompt_pre_pr_review_pass3.md
+++ b/prompt_pre_pr_review_pass3.md
@@ -1,0 +1,91 @@
+# jrdev — Pre-PR review — Pass 3 (test design, no check execution)
+
+You are in the **integration git worktree** on branch **`{{.IntegrationBranch}}`**. This is **Pass 3 only**: review **test design**, **coverage**, and **alignment** with **PRD testing expectations** and **project-wide test strictness** inferred from **existing tests** (read source; **GM-008**).
+
+## GM-008 — no lint/unit/integration execution
+
+**Do not** run the repository’s configured **lint**, **unit**, or **integration** commands, and **do not** ask the operator to run them for you during this pass. jrdev does **not** trigger those commands in Pass 3. Base judgments on **static review** of code and tests (read files, compare patterns, trace requirements from issues/PRD text).
+
+You **may** add or improve tests as code changes; after edits, your **commit message prefix** for any commit must be **`JRDEV: Pre-PR review pass 3 -`**. End with a **clean working tree** (commit everything meaningful, or **no changes**). If you make **no** commits, you may finish with **`COMPLETE NO COMMIT`** on its own line; otherwise end with **`COMPLETE`**.
+
+## Linked issues (scope)
+
+{{range $i, $n := .IssueNumbers}}{{if $i}}, {{end}}#{{$n}}{{end}}
+
+### Issue bodies (requirements and testing expectations)
+
+{{.IssuesMarkdown}}
+
+### Linked issues and PRDs (private GitHub)
+
+If a body links to other issues (for example a parent PRD) by URL or `#n`, read them with **`gh issue view`** from the repository root — not unauthenticated HTTP or **WebFetch**.
+
+{{if .NonInteractive}}
+## Non-interactive mode
+
+Standard input is **not** a TTY. **Do not** wait for user input or ask the operator questions. Use best judgment; proceed deterministically.
+{{end}}
+
+{{if .PriorPassArtifactsMarkdown}}
+## Prior pass artifacts (Pass 1↔2 — full history)
+
+{{.PriorPassArtifactsMarkdown}}
+
+{{end}}
+
+## Session handoff (Pass 1↔2 — `handoff.json`)
+
+Summary JSON written by jrdev after the matrix loop (draft PR text, gap notes, final round):
+
+```json
+{{.SessionHandoffJSON}}
+```
+
+**Final Pass 1↔2 round**: {{.FinalRound}}
+
+## Repository context
+
+Last commits in this worktree:
+
+```
+{{.CommitHistory}}
+```
+
+Diff ({{.IntegrationBase}}..HEAD):
+
+```
+{{.GitDiff}}
+```
+
+**Integration base**: `{{.IntegrationBase}}`
+
+## Task
+
+1. From issue/PRD text, infer **what testing the branch is expected to demonstrate** (explicit or implied).
+2. From **representative existing tests** (same packages, similar commands in `*_test.go`), infer **local conventions**: table-driven style, helper patterns, assertion style, error handling in tests, etc.
+3. Assess whether **current tests** on this branch **adequately** cover the linked requirements and edge cases **by design** (not by running the suite).
+4. If gaps are clear and **small**, **add or refine tests** (still **no** lint/unit/integration **execution** in this pass). Prefer minimal, consistent changes.
+5. Emit **exactly one** markdown fenced block tagged **`jrdev-pre-pr-review-pass3`** containing a single JSON object with:
+   - **`summary`**: one short paragraph on overall test posture for this branch
+   - **`testDesign`**: key design choices, strengths, or weaknesses you observed
+   - **`coverage`**: what seems covered vs. missing or risky (reasoning only; no executed coverage reports)
+   - **`prdTestingAlignment`**: how tests match (or miss) PRD/issue testing expectations
+   - **`strictnessInference`**: how you inferred project-wide strictness from existing tests (cite a few **file paths** only)
+   - **`followUps`**: optional remaining work for the human author (empty string if none)
+
+Example structure (replace with real analysis):
+
+```jrdev-pre-pr-review-pass3
+{
+  "summary": "",
+  "testDesign": "",
+  "coverage": "",
+  "prdTestingAlignment": "",
+  "strictnessInference": "",
+  "followUps": ""
+}
+```
+
+## Completion
+
+After the artifact fence (and any commits), end with **`COMPLETE`** or **`COMPLETE NO COMMIT`** on its own line, consistent with working-tree state.

--- a/prompt_pre_pr_review_pass5.md
+++ b/prompt_pre_pr_review_pass5.md
@@ -1,0 +1,65 @@
+# jrdev — Pre-PR review — Pass 5 (fix checks from jrdev-captured logs only)
+
+You are in the **integration git worktree** on branch **`{{.IntegrationBranch}}`**.
+
+jrdev ran **Pass 4** (`lint` → `unit` → `integration` from `.jrdev/config.yaml`) and stopped at the **first failing command**. You receive **only the captured stdout/stderr below** — **do not** assume you must re-run the full suite inside this session (GM-010).
+
+## Failure summary
+
+- **Failing step kind**: `{{.FailingKind}}`
+- **Command**: `{{.FailingCommand}}`
+- **Stable fingerprint (for your awareness)**: `{{.Fingerprint}}`
+- **Pass 5 round**: {{.Pass5Round}} of up to 4 (3 regular + 1 bonus on the same fingerprint)
+
+### Captured output (stdout/stderr)
+
+```
+{{.CapturedLogs}}
+```
+
+## GM-010 — test and fix rules
+
+- You **may** change **product code** and **lint** issues.
+- **Test edits** are limited to **mechanical** fixes (imports, compile breaks, small helpers) and **snapshot/golden updates** when the **product** change is already **PRD-correct**.
+- **Forbidden**: weakening assertions, mocks, skips, or tolerances **only** to make checks green.
+- If the failure is a **bad test by design** (the test is wrong relative to the PRD, and “fixing” it would mean watering it down), **stop** test surgery. Do **not** force green by mutilating the test. Instead, record that in the handoff fence (below) so the human can handle it in the PR.
+
+{{if .NonInteractive}}
+## Non-interactive mode
+
+Standard input is **not** a TTY. **Do not** wait for user input. Use best judgment; proceed deterministically.
+{{end}}
+
+{{if .BonusSteeringNote}}
+## Bonus round steering note (from operator or jrdev default)
+
+{{.BonusSteeringNote}}
+
+{{end}}
+
+## Task
+
+1. Diagnose the failure using **only** the logs and by **reading relevant source/tests** in the repo.
+2. Apply minimal, PRD-aligned fixes. Prefer product fixes over test hacks.
+3. **`go vet` / `go test` / configured commands**: you **may** run narrow commands locally if needed to validate edits — jrdev does not require you to re-run the full pipeline.
+4. Use commit messages prefixed with **`JRDEV: Pre-PR review pass 5 -`** for any commits.
+5. Leave a **clean working tree** (commit meaningful work, or **no** changes). If you make **no** commits, end with **`COMPLETE NO COMMIT`** on its own line; otherwise end with **`COMPLETE`**.
+
+### Optional handoff fence (JSON)
+
+If you stopped because of a **bad test by design**, or you have **operator-facing notes** for the PR body, emit **at most one** markdown fence tagged **`jrdev-pre-pr-review-pass5-handoff`** containing a JSON object:
+
+```jrdev-pre-pr-review-pass5-handoff
+{
+  "badTestByDesign": "",
+  "operatorNotes": ""
+}
+```
+
+Use **empty strings** when a field does not apply. jrdev merges non-empty values into `handoff.json`.
+
+## Linked issues (scope)
+
+{{range $i, $n := .IssueNumbers}}{{if $i}}, {{end}}#{{$n}}{{end}}
+
+**Integration base**: `{{.IntegrationBase}}`


### PR DESCRIPTION
## Summary

- Adds **`jrdev pre-pr-review`**: discovers linked issues from **`Fixes` / `Closes` / `Resolves`** in **`git log`** (over a configurable integration base) and **`gh pr view`**, fails fast when none are found, and runs a **multi-pass agent workflow** with embedded prompts and artifacts under **`.jrdev/pre-pr-review/`** (per **PRD #8**).
- **Pass 1** extracts and validates a single **`jrdev-prd-matrix`** fence (**GM-005**), with a repair pass on failure; writes **pass-1** / **raw-matrix** artifacts and an **`latest`** pointer (**run ID** constrained to **8-hex**).
- **Passes 1↔2** loop (rounds, prior artifacts in prompts, **handoff.json**, **GM-012**) with a **clean working tree** required after Pass 2; **Pass 3** orchestration and fenced **`pass-3.json`**; **Pass 4** runs **ProjectConfig** lint → unit → integration with **stop-on-first-failure** and captured logs for **Pass 5**; **Pass 5** is a bounded fix loop using **jrdev logs**, fingerprints (**normalized timestamps**), optional **bonus steering**, and an optional **`jrdev-pre-pr-review-pass5-handoff`** fence merged into **handoff.json**.
- **Git / agent plumbing**: **`GitDiffForPromptFromBase`**, **`GitWorkingTreeClean`** / **`RequireGitWorkingTreeClean`**; Pass 1 diff aligns with the **same integration base** as issue discovery; **`runAgentUntilComplete`** supports **TTY** runs with **stdin** and **tee’d stdout/stderr** while still buffering for **COMPLETE** detection.
- **PR generation**: **`PullRequestTitleAndBody`** loads **`.jrdev/pre-pr-review/latest`** and extends **PR** prompt data / **`prompt_pr.md`** with **handoff summaries and artifact paths** (warns if dirs or pass files are missing; **no hard failure**); **pre-pr-review** still does **not** call **`gh pr create`**.
- **Hardening**: **`latest`** run IDs are **validated as 8-hex** before **`filepath.Join`** so pointers cannot escape the pre-pr-review tree; **Pass 5** treats missing handoff fences via **`ExtractSingleMarkdownFence`** only to avoid false positives from prose mentioning the tag.
- **Repo**: **`.gitignore`** adds **`.jrdev/pre-pr-review/`** (alongside existing agent-runs ignore).

## Notes

- **Scope / tracking**: Commits reference **issues #9–#13** and **PRD #8** (close those issues when this lands, per commit messages).
- **Risks / ops**: Orchestration is **git- and `gh`-dependent**; reviewers should sanity-check **artifact layout**, **integration-base** behavior, and **non-TTY** vs **TTY** agent paths.
- **Follow-ups**: Anything that must stay **human-only** (e.g. **“bad test by design”**) is intended to surface via **Pass 5 handoff** / **handoff.json** rather than silent green builds.