### PR TITLE
Add Cloud Agent development environment setup

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,5 +1,4 @@
 {
-  "build": {
-    "install": "curl -fsSL https://raw.githubusercontent.com/KroniK907/agent-config/v1.0.1/scripts/bootstrap-agent.sh | bash"
-  }
+  "name": "jrdev",
+  "install": "bash .cursor/setup.sh"
 }

--- a/.cursor/setup.sh
+++ b/.cursor/setup.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Cloud Agent install hook for the jrdev development environment.
+#
+# Responsibilities (idempotent, non-interactive):
+#   1. Install the Go toolchain pinned by go.mod (go 1.26) — required.
+#   2. Warm the module cache and build the jrdev binary — required.
+#   3. Install the Cursor `agent` CLI that jrdev drives — best effort.
+#   4. Copy agent skills/rules from the agent-config manifest — best effort.
+#
+# Steps 3 and 4 reach the public network; when they fail the environment is
+# still fully usable for building, vetting, and testing jrdev, so they only warn.
+set -euo pipefail
+
+GO_VERSION="1.26.7"
+GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
+GO_URL="https://go.dev/dl/${GO_TARBALL}"
+
+log() { echo "jrdev-setup: $*"; }
+warn() { echo "jrdev-setup: WARNING: $*" >&2; }
+
+# Run a command as root, using sudo only when we are not already root.
+run_root() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+install_go() {
+  if command -v go >/dev/null 2>&1 && go version 2>/dev/null | grep -q "go${GO_VERSION} "; then
+    log "Go ${GO_VERSION} already present ($(go version))"
+    return 0
+  fi
+  log "Installing Go ${GO_VERSION}..."
+  local tmp
+  tmp="$(mktemp -d)"
+  curl -fsSL -o "${tmp}/${GO_TARBALL}" "${GO_URL}"
+  run_root rm -rf /usr/local/go
+  run_root tar -C /usr/local -xzf "${tmp}/${GO_TARBALL}"
+  rm -rf "${tmp}"
+  # /usr/local/bin precedes /usr/bin on PATH, so these symlinks shadow any
+  # older distro Go for every shell without editing profile files.
+  run_root ln -sf /usr/local/go/bin/go /usr/local/bin/go
+  run_root ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+  hash -r
+  log "Installed $(go version)"
+}
+
+build_jrdev() {
+  log "Downloading Go modules..."
+  go mod download
+  log "Building jrdev (warms the build cache)..."
+  go build ./...
+  log "Build complete."
+}
+
+install_cursor_agent() {
+  if command -v agent >/dev/null 2>&1; then
+    log "Cursor agent CLI already on PATH ($(command -v agent))"
+    return 0
+  fi
+  log "Installing Cursor agent CLI..."
+  if ! curl -fsS https://cursor.com/install | bash; then
+    warn "Cursor agent CLI install failed; 'jrdev' runs need it but build/test do not."
+    return 0
+  fi
+  # The installer drops binaries in ~/.local/bin, which is not on PATH by
+  # default; expose `agent` via /usr/local/bin so jrdev can resolve it.
+  if [ -e "${HOME}/.local/bin/agent" ]; then
+    run_root ln -sf "${HOME}/.local/bin/agent" /usr/local/bin/agent
+  fi
+  if command -v agent >/dev/null 2>&1; then
+    log "Cursor agent CLI installed ($(command -v agent))"
+  else
+    warn "Cursor agent CLI installed under ~/.local/bin but not resolvable on PATH."
+  fi
+}
+
+bootstrap_agent_config() {
+  local manifest=".cursor/agent-manifest.json"
+  if [ ! -f "${manifest}" ]; then
+    log "No ${manifest}; skipping agent-config bootstrap."
+    return 0
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    warn "jq not found; skipping agent-config bootstrap."
+    return 0
+  fi
+  log "Bootstrapping agent skills/rules from ${manifest}..."
+  if ! curl -fsSL https://raw.githubusercontent.com/KroniK907/agent-config/v1.0.1/scripts/bootstrap-agent.sh | bash; then
+    warn "agent-config bootstrap failed; agent skills/rules may be missing."
+  fi
+}
+
+install_go
+build_jrdev
+install_cursor_agent
+bootstrap_agent_config
+
+log "Environment ready."

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ dist/*
 .cursor/agent-config/
 !.cursor/agent-manifest.json
 !.cursor/environment.json
+!.cursor/setup.sh
 # <<< agent-config-wizard <<<


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a working Cloud Agent development environment for `jrdev`. The base image ships Go 1.22, but `go.mod` pins `go 1.26`, so the project could not build or test in the previous environment (which only ran the agent-config skills/rules bootstrap).

## Changes

- **`.cursor/setup.sh`** (new, repo-managed install hook), idempotent and non-interactive:
  - Installs the **Go 1.26.7** toolchain pinned by `go.mod` into `/usr/local/go` and symlinks `go`/`gofmt` into `/usr/local/bin` (which precedes `/usr/bin` on `PATH`, shadowing the older distro Go for every shell).
  - Warms the module and build cache with `go mod download` + `go build ./...`.
  - Installs the Cursor `agent` CLI that `jrdev` drives (best effort — build/test do not need it).
  - Preserves the existing `agent-config` skills/rules bootstrap (best effort).
- **`.cursor/environment.json`** — names the environment `jrdev` and points `install` at `.cursor/setup.sh`.
- **`.gitignore`** — allowlists `.cursor/setup.sh` so the repo-managed hook is tracked (`.cursor/*` is otherwise ignored).

Go install and the build are required steps; network-dependent extras (agent CLI, agent-config bootstrap) only warn on failure so the environment stays usable for building, vetting, and testing.

## Validation

All commands run on a clean `PATH`:

| Check | Result |
| --- | --- |
| `go build ./...` | Passed (Go 1.26.7) |
| `go vet ./...` (config `lint`) | Passed |
| `go test ./...` (config `unit`) | Passed |
| `go test -count=1 ./...` (config `integration`) | Passed (~30s) |
| `jrdev --dry-run -v` (real GitHub queue query) | Passed — repo/config discovery, `git`/`gh`/`agent` resolution, `agent-queue` query |
| `.cursor/setup.sh` idempotence | Ran twice cleanly |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de735a8c-1842-46c6-bdb3-32b621629a4c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de735a8c-1842-46c6-bdb3-32b621629a4c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

